### PR TITLE
feat(episodes): add Episode catalog substrate

### DIFF
--- a/src/episodes/index.ts
+++ b/src/episodes/index.ts
@@ -1,0 +1,17 @@
+export type {
+  Episode,
+  EpisodeCommentatorConfig,
+  EpisodeExportConfig,
+  EpisodeLifecycle,
+  EpisodePublishedRef,
+  EpisodeShortClip,
+  EpisodeSource,
+} from './types';
+export { DEFAULT_COMMENTATOR, episodeLifecycle } from './types';
+export {
+  CHESS_EPISODES,
+  DEFAULT_EPISODE_ID,
+  DEFAULT_EXPORT_EPISODE_ID,
+  getEpisode,
+  listEpisodesBySource,
+} from './registry';

--- a/src/episodes/registry.ts
+++ b/src/episodes/registry.ts
@@ -1,0 +1,27 @@
+import type { Episode, EpisodeSource } from './types';
+
+/**
+ * All registered Chess Episodes in display order.
+ *
+ * Adding an episode: build its directory under `src/episodes/<id>/` and
+ * append the exported `*_EPISODE` constant here. PR 1 ships the substrate
+ * with an empty list; the first historic episode (Opera Game) lands in
+ * PR 2.
+ */
+export const CHESS_EPISODES: Episode[] = [];
+
+/** Default episode id when no `?episode=` is specified. Empty until PR 2. */
+export const DEFAULT_EPISODE_ID: string | undefined = CHESS_EPISODES[0]?.id;
+
+/** Default episode id used by export scripts when no `--episode=` flag is passed. */
+export const DEFAULT_EXPORT_EPISODE_ID: string | undefined = CHESS_EPISODES[0]?.id;
+
+/** Look up an episode by id. */
+export function getEpisode(id: string): Episode | undefined {
+  return CHESS_EPISODES.find((episode) => episode.id === id);
+}
+
+/** All episodes that originated from the named source kind. */
+export function listEpisodesBySource(source: EpisodeSource): Episode[] {
+  return CHESS_EPISODES.filter((episode) => episode.source === source);
+}

--- a/src/episodes/types.ts
+++ b/src/episodes/types.ts
@@ -1,0 +1,152 @@
+/**
+ * Episode contract — the catalog entry for one published LLM Chess
+ * historic-game review video.
+ *
+ * The shape is intentionally parallel to Clio's `Artifact`:
+ * a typed product (PGN + commentator config + export plan + lifecycle)
+ * that the export pipeline compiles down to one full-length video and
+ * zero or more vertical Shorts.
+ *
+ * Two production paths converge on the same Episode shape via the
+ * `source` field:
+ *
+ *   `public_domain`   game from the historic public-domain corpus
+ *                     (Morphy, pre-1923 tournament games, etc.)
+ *   `licensed`        game from a licensed/curated source (modern
+ *                     tournament with permission, study material)
+ *   `agent_generated` an LLM-vs-LLM game we want to publish (output of
+ *                     the existing arena/tournament runtime)
+ *
+ * The capture pipeline (added in a later PR) does not need to know
+ * which path produced the PGN — it just consumes the Episode.
+ */
+
+export interface Episode {
+  /** Stable identifier (lowercase, underscored). Matches `exports/<id>/`. */
+  id: string;
+  /** Display title used in the UI and on the published video. */
+  title: string;
+  /** One-paragraph summary for catalog views and the YouTube description. */
+  summary: string;
+  /** Where the underlying game came from. */
+  source: EpisodeSource;
+  /** Full PGN text including headers. */
+  pgn: string;
+  /** Commentator LLM config — model, voice, system-prompt overrides. */
+  commentator: EpisodeCommentatorConfig;
+  /**
+   * Historical context injected into the commentator system prompt so it
+   * has dates, tournament names, player background, and any quirks worth
+   * narrating without having to recall them.
+   */
+  historicalContext?: string;
+  /** Export configuration. Present once the episode is planned for export. */
+  exports?: EpisodeExportConfig;
+  /** Published references (e.g. YouTube URLs). Workspace-tracked. */
+  published?: EpisodePublishedRef[];
+}
+
+/** Provenance of the PGN that backs the Episode. */
+export type EpisodeSource = 'public_domain' | 'licensed' | 'agent_generated';
+
+/** Lifecycle stages an Episode moves through. Derived from data, not stored. */
+export type EpisodeLifecycle = 'draft' | 'scripted' | 'exported' | 'published';
+
+/**
+ * Commentator config attached to an Episode. The default for the channel is
+ * `DEFAULT_COMMENTATOR` below; per-episode overrides only when a specific
+ * game intentionally wants a different style.
+ */
+export interface EpisodeCommentatorConfig {
+  /**
+   * LLM provider key. Must match a provider registered in `src/llm/client.ts`
+   * (today: `'openai' | 'openrouter' | 'ollama' | 'codex'`).
+   */
+  provider: string;
+  /**
+   * Model identifier as accepted by the provider client. For OpenAI this is
+   * the canonical model id (e.g. the GPT 5.5 release identifier registered
+   * in `model-capabilities.ts`).
+   */
+  model: string;
+  /**
+   * Optional TTS voice id. Used by the OpenAI TTS path; ignored by other
+   * providers.
+   */
+  voice?: string;
+  /**
+   * Optional system-prompt addition merged into the commentator's base
+   * prompt. Use this for per-episode framing (e.g. era-specific tone) when
+   * the global commentator system prompt is not enough.
+   */
+  systemPromptAddition?: string;
+}
+
+/**
+ * One short to slice from an Episode's full video. Mirrors the
+ * `ClipManifestEntry` shape on the Clio side, but ranges are expressed in
+ * chess move numbers (1-indexed full moves) rather than script segment
+ * indices, since chess content is naturally addressable by move.
+ */
+export interface EpisodeShortClip {
+  id: string;
+  /** First full-move number (1-indexed) covered by the short. Inclusive. */
+  startMoveNumber: number;
+  /** Last full-move number covered by the short. Inclusive. */
+  endMoveNumber: number;
+  /** Hook line for thumbnails / metadata. */
+  hook: string;
+  /** Payoff/CTA line. */
+  payoff: string;
+  cta?: string;
+  /** Target duration in seconds (used for pacing, not a hard cap). */
+  durationTargetSec: number;
+  /** Free-form visual requirements for human review (e.g. "show the bishop sac"). */
+  visualRequirements?: string[];
+}
+
+/** Export configuration attached to an Episode. */
+export interface EpisodeExportConfig {
+  /** npm script that exports this episode end-to-end. */
+  command: string;
+  /** Output root for rendered files (typically `'exports'`). */
+  outputRoot: string;
+  /** Candidate descriptions for the published video (YouTube etc.). */
+  descriptionCandidates: string[];
+  /** Shorts to slice from the full video. */
+  shorts: EpisodeShortClip[];
+}
+
+/** A published reference for an Episode (e.g. a YouTube upload). */
+export interface EpisodePublishedRef {
+  platform: 'youtube' | string;
+  url: string;
+  publishedAt: string;
+  format: 'full' | 'short';
+  /** Required when `format === 'short'`; must match a short id in the export config. */
+  shortId?: string;
+  notes?: string;
+}
+
+/**
+ * Channel-default commentator. Picked once and locked so episodes have a
+ * recognizable voice across uploads.
+ *
+ * NOTE on the model identifier: the canonical OpenAI id for GPT 5.5 is
+ * registered alongside the rest of the model catalog in
+ * `src/llm/model-capabilities.ts`. If the id shifts (renames, version bumps),
+ * keep this default in sync.
+ */
+export const DEFAULT_COMMENTATOR: EpisodeCommentatorConfig = {
+  provider: 'openai',
+  model: 'gpt-5.5',
+  voice: 'nova',
+};
+
+/** Derive the current lifecycle stage from an Episode's data. */
+export function episodeLifecycle(episode: Episode): EpisodeLifecycle {
+  if (!episode.pgn.trim()) return 'draft';
+  if (!episode.exports) return 'scripted';
+  if (episode.published && episode.published.length > 0) return 'published';
+  return 'exported';
+}


### PR DESCRIPTION
## Summary
- Introduces `src/episodes/` — a typed catalog for LLM Chess historic-game review videos. Shape is parallel to Clio's `Artifact` contract: each episode owns a directory under `src/episodes/<id>/` with PGN, commentator config, research backing, and an export plan.
- Three files, no behavior changes: [`types.ts`](src/episodes/types.ts) (Episode, EpisodeCommentatorConfig, EpisodeShortClip, EpisodeExportConfig, EpisodePublishedRef, lifecycle helpers, plus `DEFAULT_COMMENTATOR` locked to OpenAI GPT 5.5), [`registry.ts`](src/episodes/registry.ts) (empty `CHESS_EPISODES` array + getEpisode/listEpisodesBySource helpers), [`index.ts`](src/episodes/index.ts).
- Episodes carry a `source` field distinguishing the three production paths converging on the same shape: `public_domain` (Morphy + pre-1923 corpus), `licensed` (curated modern material), `agent_generated` (publishable LLM-vs-LLM games out of the existing arena/tournament runtime).
- Channel-default commentator is **GPT 5.5 via OpenAI** — picked once, locked here. Per-episode override only when a specific game intentionally wants a different style.

## Why now
First step in adding MP4 export so the YouTube channel can publish historic-game reviews. The follow-up sequence:
1. **PR 2** — first historic episode (Opera Game, Morphy 1858 — short, iconic, public domain).
2. **PR 3** — export-mode bridge in the React app (`runtimeConfig`, `__CHESS_EXPORT__` window bridge), so headless capture can drive replay + commentary + TTS gating without touching interactive UI.
3. **PR 4** — `scripts/lib/replay-mp4.ts` capture pipeline (Vite + Playwright + ffmpeg), `scripts/export-chess-episode.ts` CLI, npm scripts.

## Coordination note
The `DEFAULT_COMMENTATOR.model` value (`'gpt-5.5'`) is a placeholder for the canonical OpenAI model identifier registered in `src/llm/model-capabilities.ts`. The parallel branch `add-opus-4.7-chatgpt-5.5` is wiring that model in; once it lands, sync this default to the exact id used there. There's no runtime collision in the meantime — this PR adds no consumers of the value yet.

## Test plan
- [x] `npx tsc --noEmit` against the three new files — clean.
- [ ] Once PR 2 lands and registers the first episode, follow-up: `getEpisode('opera_game_morphy_1858')` resolves and `episodeLifecycle()` returns the expected stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added foundational infrastructure for organizing and managing chess video episodes, including data structures, configuration options, and utility functions for efficient content lookup and access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->