### PR TITLE
feat(episodes): add Opera Game (Morphy 1858) as the first episode

### DIFF
--- a/src/episodes/index.ts
+++ b/src/episodes/index.ts
@@ -15,3 +15,4 @@ export {
   getEpisode,
   listEpisodesBySource,
 } from './registry';
+export { OPERA_GAME_EPISODE } from './opera_game_morphy_1858';

--- a/src/episodes/opera_game_morphy_1858/commentator.ts
+++ b/src/episodes/opera_game_morphy_1858/commentator.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_COMMENTATOR, type EpisodeCommentatorConfig } from '../types';
+
+/**
+ * Per-episode commentator config for the Opera Game.
+ *
+ * Uses the channel-default voice (GPT 5.5 via OpenAI, `nova`) and adds an
+ * episode-specific system-prompt addition so the commentator knows it is
+ * narrating an instructive 19th-century game, not a modern engine match.
+ */
+export const OPERA_GAME_COMMENTATOR: EpisodeCommentatorConfig = {
+  ...DEFAULT_COMMENTATOR,
+  systemPromptAddition: [
+    'You are reviewing the Opera Game, played by Paul Morphy in 1858 against Duke Karl of Brunswick and Count Isouard, who were consulting together as a single player against Morphy.',
+    'Treat this as a teaching exposition for an audience that has heard of the game but has never had a master patiently walk through it.',
+    'Lean into the open-game development principles Morphy is illustrating: rapid piece activity, central control, the cost of weakening the king before development is complete.',
+    'When the sacrifices begin (move 10 onward), name the tactical motifs explicitly — pin, discovered attack, removal of the defender, decoy, deflection, mating net.',
+    'Avoid modern engine vocabulary that would feel anachronistic for a 19th-century game. Speak as a thoughtful instructor, not as a Stockfish read-out.',
+    'On the final mate (Rd8#), pause to acknowledge the Queen sacrifice on the prior move (Qb8+!!) — that move is what makes the combination immortal.',
+  ].join(' '),
+};

--- a/src/episodes/opera_game_morphy_1858/exports.ts
+++ b/src/episodes/opera_game_morphy_1858/exports.ts
@@ -1,0 +1,46 @@
+import type { EpisodeExportConfig } from '../types';
+
+/**
+ * Export configuration for the Opera Game episode.
+ *
+ * Two shorts: the buildup (development through castling-with-check,
+ * moves 8-12) and the finishing combination (rook sacrifice through
+ * mate, moves 13-17). Together they cover the full game; published
+ * separately each is a standalone tactical lesson.
+ */
+export const OPERA_GAME_EXPORT: EpisodeExportConfig = {
+  command: 'npm run export:opera-game',
+  outputRoot: 'exports',
+  descriptionCandidates: [
+    'A patient walkthrough of Paul Morphy\'s 1858 Opera Game — the most famous game in chess history, played in 17 moves at the Salle Le Peletier opera house in Paris during a performance of Bellini\'s Norma. Commentary by GPT 5.5.',
+  ],
+  shorts: [
+    {
+      id: 'opera_game_setup',
+      startMoveNumber: 8,
+      endMoveNumber: 12,
+      durationTargetSec: 75,
+      hook: 'Morphy sets the trap.',
+      payoff: 'Five moves take the position from "normal opening" to "Black\'s king has nowhere to hide."',
+      visualRequirements: [
+        'show the Bg5 pin and the b5 weakening',
+        'arrow the Nxb5 sacrifice and the recaptures',
+        'highlight the d-file opening up after O-O-O',
+      ],
+    },
+    {
+      id: 'opera_game_combination',
+      startMoveNumber: 13,
+      endMoveNumber: 17,
+      durationTargetSec: 75,
+      hook: 'The five-move combination that ends in checkmate.',
+      payoff: 'The queen sacrifice on move 16 (Qb8+!!) is what makes this game immortal.',
+      cta: 'Subscribe for more historic-game reviews from the Mnemosyne Research Institute.',
+      visualRequirements: [
+        'show the Rxd7 exchange sacrifice clearly',
+        'arrow Bxd7+ then Qb8+!! then Rd8#',
+        'pause on the final position with mate annotated',
+      ],
+    },
+  ],
+};

--- a/src/episodes/opera_game_morphy_1858/index.ts
+++ b/src/episodes/opera_game_morphy_1858/index.ts
@@ -1,0 +1,24 @@
+import type { Episode } from '../types';
+import { OPERA_GAME_PGN } from './pgn';
+import { OPERA_GAME_COMMENTATOR } from './commentator';
+import { OPERA_GAME_HISTORICAL_CONTEXT } from './research';
+import { OPERA_GAME_EXPORT } from './exports';
+
+export const OPERA_GAME_EPISODE: Episode = {
+  id: 'opera_game_morphy_1858',
+  title: 'The Opera Game — Morphy vs Brunswick and Isouard, 1858',
+  summary:
+    'Paul Morphy beats two consulting aristocrats in 17 moves at the Paris Opera, finishing with the queen sacrifice and rook mate that has been taught to chess students for the next 168 years.',
+  source: 'public_domain',
+  pgn: OPERA_GAME_PGN,
+  commentator: OPERA_GAME_COMMENTATOR,
+  historicalContext: OPERA_GAME_HISTORICAL_CONTEXT,
+  exports: OPERA_GAME_EXPORT,
+};
+
+export {
+  OPERA_GAME_PGN,
+  OPERA_GAME_COMMENTATOR,
+  OPERA_GAME_HISTORICAL_CONTEXT,
+  OPERA_GAME_EXPORT,
+};

--- a/src/episodes/opera_game_morphy_1858/pgn.ts
+++ b/src/episodes/opera_game_morphy_1858/pgn.ts
@@ -1,0 +1,25 @@
+/**
+ * Opera Game — Paul Morphy vs Duke of Brunswick & Count Isouard.
+ * Played in 1858 in the Duke's box at the Salle Le Peletier (Paris Opera)
+ * during a performance of Bellini's Norma.
+ *
+ * 17 moves. White wins by checkmate. Public domain.
+ *
+ * Source: standard PGN as preserved in chessgames.com and reproduced in
+ * every introductory chess book since Reinfeld and Chernev. The headers
+ * are normalized to the consensus form used by the chess history record.
+ */
+export const OPERA_GAME_PGN = `[Event "Casual Game"]
+[Site "Paris Opera, Paris FRA"]
+[Date "1858.??.??"]
+[Round "-"]
+[White "Paul Morphy"]
+[Black "Duke Karl of Brunswick / Count Isouard"]
+[Result "1-0"]
+[ECO "C41"]
+[Opening "Philidor Defense"]
+
+1. e4 e5 2. Nf3 d6 3. d4 Bg4 4. dxe5 Bxf3 5. Qxf3 dxe5 6. Bc4 Nf6 7. Qb3 Qe7
+8. Nc3 c6 9. Bg5 b5 10. Nxb5 cxb5 11. Bxb5+ Nbd7 12. O-O-O Rd8 13. Rxd7 Rxd7
+14. Rd1 Qe6 15. Bxd7+ Nxd7 16. Qb8+ Nxb8 17. Rd8# 1-0
+`;

--- a/src/episodes/opera_game_morphy_1858/research.ts
+++ b/src/episodes/opera_game_morphy_1858/research.ts
@@ -1,0 +1,43 @@
+/**
+ * Historical context injected into the commentator's system prompt so it
+ * has dates, players, venue, and famous moves to reference without having
+ * to recall them.
+ *
+ * Sources: Edward Winter's chess-history columns (Chess Notes), the
+ * Wikipedia article "Opera Game", and standard reference works including
+ * Kasparov's "My Great Predecessors" Vol. 1 and Reinfeld's annotated
+ * collections. The Norma performance attribution is the consensus account
+ * recorded by Morphy's contemporaries.
+ */
+export const OPERA_GAME_HISTORICAL_CONTEXT = `
+The Opera Game was played in 1858 in Paris, in the box of Duke Karl II of
+Brunswick at the Salle Le Peletier opera house, during a performance of
+Vincenzo Bellini's "Norma." Paul Morphy, age 21 and on the European tour
+that established him as the strongest player in the world, played White.
+The Duke and his frequent chess partner Count Isouard de Vauvenargues
+played Black as a consulting pair against Morphy.
+
+The game opens with the Philidor Defense (1.e4 e5 2.Nf3 d6). Morphy plays
+classical principles — rapid development, central control, castling early
+— while Black falls behind in development and weakens the queenside with
+9...b5 in response to the Bg5 pin on the f6 knight.
+
+From move 10 onward, Morphy executes a textbook attacking sequence:
+- 10.Nxb5! sacrificing the knight to open lines against the king,
+- 11.Bxb5+ recapturing with check while pinning the new defender,
+- 12.O-O-O+ castling long with discovered check, bringing the rook to the
+  open d-file and aiming directly at the Black king,
+- 13.Rxd7! exchange sacrifice removing the only defending knight,
+- 14.Rd1 doubling on the d-file,
+- 15.Bxd7+ continuing the assault,
+- 16.Qb8+!! the immortal queen sacrifice that decoys the Black knight to
+  b8 and clears d8 for the rook,
+- 17.Rd8# the final mate.
+
+Morphy is reported to have been watching the opera while playing, and his
+opponents reportedly only realized the situation when 16.Qb8+ landed on
+the board. The game has been used as a first-tutorial demonstration for
+generations of chess students because every move teaches a discrete
+principle (development, the open file, the pin, the sacrifice for tempo,
+the mating net) without any of the obscuring complexity of modern theory.
+`.trim();

--- a/src/episodes/registry.ts
+++ b/src/episodes/registry.ts
@@ -1,16 +1,17 @@
+import { OPERA_GAME_EPISODE } from './opera_game_morphy_1858';
 import type { Episode, EpisodeSource } from './types';
 
 /**
  * All registered Chess Episodes in display order.
  *
  * Adding an episode: build its directory under `src/episodes/<id>/` and
- * append the exported `*_EPISODE` constant here. PR 1 ships the substrate
- * with an empty list; the first historic episode (Opera Game) lands in
- * PR 2.
+ * append the exported `*_EPISODE` constant here.
  */
-export const CHESS_EPISODES: Episode[] = [];
+export const CHESS_EPISODES: Episode[] = [
+  OPERA_GAME_EPISODE,
+];
 
-/** Default episode id when no `?episode=` is specified. Empty until PR 2. */
+/** Default episode id when no `?episode=` is specified. */
 export const DEFAULT_EPISODE_ID: string | undefined = CHESS_EPISODES[0]?.id;
 
 /** Default episode id used by export scripts when no `--episode=` flag is passed. */


### PR DESCRIPTION
> **Stacked on [#28](https://github.com/Mnehmos/LLM-Chess/pull/28)** — base is `feature/episodes-substrate`. GitHub will retarget to `main` after #28 merges.

## Summary
- Adds [`src/episodes/opera_game_morphy_1858/`](src/episodes/opera_game_morphy_1858/) — the first registered Episode under the catalog from #28: PGN, commentator config, historical context, and exports config with two shorts. Five new files plus a one-line registry update.
- Wires `OPERA_GAME_EPISODE` into `CHESS_EPISODES`, so `DEFAULT_EPISODE_ID` and `DEFAULT_EXPORT_EPISODE_ID` now resolve to `'opera_game_morphy_1858'`.
- Commentator is the channel-default GPT 5.5 via OpenAI with an episode-specific `systemPromptAddition` framing the game as a 19th-century instructive review (no engine-comparison vocabulary, name tactical motifs explicitly, pause on the queen sacrifice).
- Two shorts: **`opera_game_setup`** (moves 8-12 — the Bg5 pin through the discovered-check castle) and **`opera_game_combination`** (moves 13-17 — the rook sacrifice through Rd8#). Together they cover the full game; published separately each is a standalone tactical lesson.

## Why this game first
- 17 moves total — exercises the full pipeline at minimum cost. If anything breaks in the live-gate / capture / TTS handoff (added in PR 4), we discover it in five minutes of recording, not forty.
- Universally known, public domain, zero source friction.
- Two natural shorts already built into the game (the trap setup and the mating combination).
- Perfect first chess upload — every chess-curious viewer recognizes the title, but most have never had a master patiently walk through it.

Fischer-Spassky '72 game 6 is the obvious next episode (longer, more drama, marquee material) once Opera proves the pipeline.

## Test plan
- [x] `npx tsc --noEmit` against all new files plus the modified registry and index — clean.
- [ ] After PR 3 (export-mode bridge) and PR 4 (capture pipeline) land, render end-to-end with `npm run export:opera-game` and review the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)