### PR TITLE
Normalize provider message content extraction

### DIFF
--- a/src/llm/content.ts
+++ b/src/llm/content.ts
@@ -1,0 +1,19 @@
+export function extractMessageContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map(extractMessageContentPart).join('');
+  }
+  return extractMessageContentPart(content);
+}
+
+function extractMessageContentPart(part: unknown): string {
+  if (typeof part === 'string') return part;
+  if (!part || typeof part !== 'object') return '';
+
+  const record = part as Record<string, unknown>;
+  if (typeof record.text === 'string') return record.text;
+  if (typeof record.content === 'string') return record.content;
+  if (Array.isArray(record.content)) return record.content.map(extractMessageContentPart).join('');
+
+  return '';
+}

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -4,6 +4,7 @@ import type { ChatMessage } from './prompts';
 import type { LLMRawResponse } from './parser';
 import { buildChessPrompt, buildRetryPrompt, buildRetryPromptForReason, buildCommentaryPrompt, type CommentaryContext, type RetryReason } from './prompts';
 import { buildResponseFormat, shouldStream, buildReasoningParams, getAdaptiveMoveTokenBudget } from './model-capabilities';
+import { extractMessageContent } from './content';
 
 const DEFAULT_BASE_URL = 'http://localhost:11434';
 
@@ -112,7 +113,7 @@ export class OllamaClient {
     if (!choice) throw new Error('No choices in Ollama response');
 
     return {
-      content: choice.message?.content || '',
+      content: extractMessageContent(choice.message?.content),
       model: data.model || model,
       responseTimeMs: Date.now() - startTime,
       tokensUsed: data.usage?.total_tokens,
@@ -156,7 +157,7 @@ export class OllamaClient {
 
         try {
           const parsed = JSON.parse(data);
-          const delta = parsed.choices?.[0]?.delta?.content;
+          const delta = extractMessageContent(parsed.choices?.[0]?.delta?.content);
           if (delta) {
             if (ttftMs === undefined) ttftMs = Date.now() - startTime;
             lastTokenMs = Date.now();
@@ -218,7 +219,7 @@ export class OllamaClient {
 
       if (!response.ok) return '';
       const data = await response.json();
-      return data.choices?.[0]?.message?.content || '';
+      return extractMessageContent(data.choices?.[0]?.message?.content);
     } catch {
       return '';
     }

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -6,6 +6,7 @@ import { buildReasoningParams, buildResponseFormat, downgradeModel, getAdaptiveM
 import { PermanentAPIError, RateLimitError } from './errors';
 import type { LLMModel, MoveResponseOptions } from './client';
 import { StreamLoopGuard } from './stream-loop-guard';
+import { extractMessageContent } from './content';
 
 const OPENAI_BASE = 'https://api.openai.com/v1';
 
@@ -220,7 +221,7 @@ export class OpenAIClient {
     if (!choice) throw new Error('No choices in OpenAI response');
 
     return {
-      content: extractTextContent(choice.message?.content),
+      content: extractMessageContent(choice.message?.content),
       model: data.model || model,
       responseTimeMs: Date.now() - startTime,
       tokensUsed: data.usage?.total_tokens,
@@ -268,7 +269,7 @@ export class OpenAIClient {
         try {
           const parsed = JSON.parse(data);
           const deltaRaw = parsed.choices?.[0]?.delta?.content;
-          const delta = extractTextContent(deltaRaw);
+          const delta = extractMessageContent(deltaRaw);
           if (delta) {
             if (ttftMs === undefined) ttftMs = Date.now() - startTime;
             lastTokenMs = Date.now();
@@ -351,7 +352,7 @@ export class OpenAIClient {
       return '';
     }
     const data = await response.json();
-    return extractTextContent(data.choices?.[0]?.message?.content);
+    return extractMessageContent(data.choices?.[0]?.message?.content);
   }
 
   async requestCommentaryStream(
@@ -431,23 +432,6 @@ export class OpenAIClient {
       return false;
     }
   }
-}
-
-function extractTextContent(content: unknown): string {
-  if (typeof content === 'string') return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((part) => {
-        if (typeof part === 'string') return part;
-        if (!part || typeof part !== 'object') return '';
-        if ('text' in part && typeof (part as { text?: unknown }).text === 'string') {
-          return (part as { text: string }).text;
-        }
-        return '';
-      })
-      .join('');
-  }
-  return '';
 }
 
 function mapReasoningEffort(rawEffort: string): 'minimal' | 'low' | 'medium' | 'high' | undefined {

--- a/src/llm/openrouter.ts
+++ b/src/llm/openrouter.ts
@@ -6,6 +6,7 @@ import { buildChessPrompt, buildRetryPrompt, buildRetryPromptForReason, buildCom
 import { buildResponseFormat, shouldStream, downgradeModel, buildReasoningParams, getAdaptiveMoveTokenBudget } from './model-capabilities';
 import { PermanentAPIError, RateLimitError } from './errors';
 import { StreamLoopGuard } from './stream-loop-guard';
+import { extractMessageContent } from './content';
 
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
 const MODEL_RATE_LIMIT_UNTIL = new Map<string, number>();
@@ -239,7 +240,7 @@ export class OpenRouterClient {
     if (!choice) throw new Error('No choices in OpenRouter response');
 
     return {
-      content: choice.message?.content || '',
+      content: extractMessageContent(choice.message?.content),
       model: data.model || model,
       responseTimeMs: Date.now() - startTime,
       tokensUsed: data.usage?.total_tokens,
@@ -288,7 +289,7 @@ export class OpenRouterClient {
         try {
           const parsed = JSON.parse(data);
           const choice = parsed.choices?.[0];
-          const deltaContent = choice?.delta?.content;
+          const deltaContent = extractMessageContent(choice?.delta?.content);
           const deltaReasoning = choice?.delta?.reasoning;
           if (deltaReasoning) {
             // Thinking tokens — pass as-is so callers can show reasoning if desired
@@ -379,7 +380,7 @@ export class OpenRouterClient {
 
     if (!response.ok) return '';
     const data = await response.json();
-    return data.choices?.[0]?.message?.content || '';
+    return extractMessageContent(data.choices?.[0]?.message?.content);
   }
 
   async requestCommentaryStream(
@@ -436,7 +437,7 @@ export class OpenRouterClient {
       });
       if (retryResp.ok) {
         const retryData = await retryResp.json();
-        const retryContent = retryData.choices?.[0]?.message?.content;
+        const retryContent = extractMessageContent(retryData.choices?.[0]?.message?.content);
         if (retryContent) {
           onChunk(retryContent);
           return retryContent;


### PR DESCRIPTION
## Summary
- adds a shared message-content extractor for provider responses
- reuses it in OpenAI, OpenRouter, and Ollama non-streaming response parsing
- applies the same normalization to streamed content deltas and commentary response paths

Fixes #13.

## Verification
- `npm run build`
- `npx eslint src/llm/content.ts src/llm/openai.ts src/llm/openrouter.ts src/llm/ollama.ts`
- `git diff --check`

Note: full `npm run lint` still fails on existing unrelated React/hooks and unused-variable violations outside the LLM provider files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified message content extraction across Ollama, OpenAI, and OpenRouter integrations into a shared utility function.
  * Message content parsing now uses consistent normalization logic across all LLM providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->