### PR TITLE
feat(mp4-export): broadcast mode + window.__CHESS_EXPORT__ bridge (Phase 1, #34)

### DIFF
--- a/src/app/broadcastConfig.ts
+++ b/src/app/broadcastConfig.ts
@@ -1,0 +1,84 @@
+/**
+ * URL-driven broadcast mode for the MP4 export pipeline.
+ *
+ * The capture pipeline (Phase 3) opens the SPA with a fixed set of query
+ * params and expects a deterministic, chrome-free layout that auto-plays
+ * a known PGN. This module parses those params once at module load.
+ *
+ * The config is intentionally read-only and computed once. Re-running
+ * the capture means reloading the page — there is no in-app way to
+ * toggle broadcast mode.
+ */
+
+export interface BroadcastConfig {
+  /** True when ?export=1 is set. Strips chrome and skips the normal tab UI. */
+  exportMode: boolean;
+  /** True when ?broadcast=1 is set. Disables interactive affordances. */
+  broadcast: boolean;
+  /** Episode id from ?episode=<id>. Resolves through CHESS_EPISODES. */
+  episodeId: string | null;
+  /** Raw PGN text from ?pgn=<encoded>. Bypasses the registry. */
+  rawPgn: string | null;
+  /**
+   * Optional clip id from ?shortId=<id>. Phase 4 selects a highlight
+   * range; ignored entirely in Phase 1.
+   */
+  shortId: string | null;
+  /** Optional viewport width from ?w=<px>. Defaults to 1920. */
+  viewportWidth: number | null;
+  /** Optional viewport height from ?h=<px>. Defaults to 1080. */
+  viewportHeight: number | null;
+}
+
+function parseFlag(params: URLSearchParams, key: string): boolean {
+  const raw = params.get(key);
+  if (raw === null) return false;
+  return raw === '1' || raw === 'true';
+}
+
+function parsePositiveInt(params: URLSearchParams, key: string): number | null {
+  const raw = params.get(key);
+  if (!raw) return null;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function parse(): BroadcastConfig {
+  if (typeof window === 'undefined') {
+    return {
+      exportMode: false,
+      broadcast: false,
+      episodeId: null,
+      rawPgn: null,
+      shortId: null,
+      viewportWidth: null,
+      viewportHeight: null,
+    };
+  }
+  const params = new URLSearchParams(window.location.search);
+  return {
+    exportMode: parseFlag(params, 'export'),
+    broadcast: parseFlag(params, 'broadcast'),
+    episodeId: params.get('episode'),
+    rawPgn: params.get('pgn'),
+    shortId: params.get('shortId'),
+    viewportWidth: parsePositiveInt(params, 'w'),
+    viewportHeight: parsePositiveInt(params, 'h'),
+  };
+}
+
+let cached: BroadcastConfig | null = null;
+
+/**
+ * Returns the parsed broadcast config. Parses once on first call;
+ * subsequent calls return the cached value.
+ */
+export function getBroadcastConfig(): BroadcastConfig {
+  if (!cached) cached = parse();
+  return cached;
+}
+
+/** True if the current page load is a broadcast/export run. */
+export function isBroadcastMode(): boolean {
+  return getBroadcastConfig().exportMode;
+}

--- a/src/app/exportBridge.ts
+++ b/src/app/exportBridge.ts
@@ -1,0 +1,133 @@
+/**
+ * window.__CHESS_EXPORT__ bridge — the handshake contract between the
+ * SPA and the headless-Chromium capture pipeline (Phase 3).
+ *
+ * The capture pipeline does, in order:
+ *
+ *   1. Open the SPA with ?export=1&broadcast=1&episode=<id>
+ *   2. Wait for state().ready && painted && replayReady && audioReady
+ *   3. Call reset() and start()
+ *   4. Stream JPEG frames via CDP Page.startScreencast
+ *   5. Wait for state().ended
+ *   6. Read state().segmentTimings for audio/caption alignment
+ *
+ * Mirrors Clio's __CLIO_EXPORT__ contract so the lifted capture
+ * scaffolding (Phase 3) ports with minimal modification.
+ */
+
+export interface ExportBridgeState {
+  /** SPA has mounted and parsed broadcast config. */
+  ready: boolean;
+  /** Page has committed at least one React render plus one rAF tick. */
+  painted: boolean;
+  /** Broadcast layout is active (mirrors broadcastConfig.exportMode). */
+  broadcastMode: boolean;
+  /** PGN parsed, ChessBoard initialized, replay runtime ready to start. */
+  replayReady: boolean;
+  /** AudioContext is unlocked (or TTS is disabled). */
+  audioReady: boolean;
+  /** GameEnded / GameAborted has fired. */
+  ended: boolean;
+  /**
+   * Map of timeline-segment-index to milliseconds-since-start(),
+   * populated by AudioNarrationQueue in Phase 2. Empty in Phase 1.
+   */
+  segmentTimings: Record<number, number>;
+}
+
+/**
+ * Hooks supplied by BroadcastView so the bridge can drive the replay.
+ * The bridge owns the state machine; the React view owns the runtime
+ * lifecycle.
+ */
+export interface ExportBridgeHooks {
+  start: () => void;
+  reset: () => void;
+}
+
+export interface ExportBridge {
+  reset(): void;
+  start(): void;
+  state(): ExportBridgeState;
+  /** Internal: BroadcastView calls this after mount. */
+  __register(hooks: ExportBridgeHooks): void;
+  /** Internal: rAF callback after first paint. */
+  __markPainted(): void;
+  /** Internal: PGN loaded + ReplayRuntime ready. */
+  __markReplayReady(ready: boolean): void;
+  /** Internal: AudioContext unlocked (or TTS off). */
+  __markAudioReady(ready: boolean): void;
+  /** Internal: GameEnded / GameAborted fired. */
+  __markEnded(): void;
+  /** Internal: AudioNarrationQueue records per-segment paint offset. */
+  __recordSegmentTiming(segmentIndex: number, offsetMs: number): void;
+  /** Internal: installExportBridge sets broadcastMode at boot. */
+  __setBroadcastMode(value: boolean): void;
+}
+
+const state: ExportBridgeState = {
+  ready: false,
+  painted: false,
+  broadcastMode: false,
+  replayReady: false,
+  audioReady: false,
+  ended: false,
+  segmentTimings: {},
+};
+
+let hooks: ExportBridgeHooks | null = null;
+
+export const exportBridge: ExportBridge = {
+  reset() {
+    state.painted = false;
+    state.replayReady = false;
+    state.audioReady = false;
+    state.ended = false;
+    state.segmentTimings = {};
+    hooks?.reset();
+  },
+  start() {
+    if (!hooks) {
+      console.warn('[__CHESS_EXPORT__] start() called before BroadcastView mounted');
+      return;
+    }
+    hooks.start();
+  },
+  state() {
+    // Return a shallow copy so callers can't mutate internal state.
+    // segmentTimings is also cloned because it grows during playback.
+    return { ...state, segmentTimings: { ...state.segmentTimings } };
+  },
+  __register(newHooks) {
+    hooks = newHooks;
+    state.ready = true;
+  },
+  __markPainted() {
+    state.painted = true;
+  },
+  __markReplayReady(ready) {
+    state.replayReady = ready;
+  },
+  __markAudioReady(ready) {
+    state.audioReady = ready;
+  },
+  __markEnded() {
+    state.ended = true;
+  },
+  __recordSegmentTiming(segmentIndex, offsetMs) {
+    state.segmentTimings[segmentIndex] = offsetMs;
+  },
+  __setBroadcastMode(value) {
+    state.broadcastMode = value;
+  },
+};
+
+/**
+ * Install the bridge on the window object. Called once from main.tsx
+ * during boot. Skipped in non-browser contexts (SSR, test runner).
+ */
+export function installExportBridge(broadcastMode: boolean): void {
+  if (typeof window === 'undefined') return;
+  exportBridge.__setBroadcastMode(broadcastMode);
+  (window as unknown as { __CHESS_EXPORT__: ExportBridge }).__CHESS_EXPORT__ = exportBridge;
+}

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTournamentStore } from '../store/tournamentStore';
+import { useSettingsStore } from '../store/settingsStore';
+import { getBroadcastConfig } from '../app/broadcastConfig';
+import { exportBridge } from '../app/exportBridge';
+import { getEpisode, DEFAULT_EPISODE_ID } from '../episodes';
+import { TournamentProgress } from './TournamentProgress';
+
+/**
+ * BroadcastView — the chrome-free, auto-playing layout used by the
+ * MP4 export pipeline.
+ *
+ * Mounted by App.tsx when ?export=1 is present. Resolves the PGN
+ * source (episode id or inline pgn), registers __CHESS_EXPORT__
+ * hooks, and renders TournamentProgress — which already owns the
+ * full commentary queue, TTS, narration gate, and game layout
+ * wiring. Reusing it avoids duplicating ~1000 lines of orchestration.
+ *
+ * The bridge taps the lifecycle by watching the tournament store
+ * (activeGameState.status) rather than reaching into
+ * TournamentProgress internals.
+ */
+export function BroadcastView() {
+  const config = getBroadcastConfig();
+  const startReplay = useTournamentStore(s => s.startReplay);
+  const stopReplay = useTournamentStore(s => s.stopReplay);
+  const activeGameState = useTournamentStore(s => s.activeGameState);
+  const replayMode = useTournamentStore(s => s.replayMode);
+  const setReplayCommentatorModel = useTournamentStore(s => s.setReplayCommentatorModel);
+  const ttsEnabled = useSettingsStore(s => s.ttsEnabled);
+
+  // PGN source resolution. Broadcast config comes from URL params and
+  // never changes during a page lifetime, so we resolve once with a
+  // lazy useState initializer — no effect, no cascading renders.
+  const [pgnText] = useState<string | null>(() => resolvePgnSource(config).pgnText);
+  const [loadError] = useState<string | null>(() => resolvePgnSource(config).error);
+  const [historicalContext] = useState<string | undefined>(() => resolvePgnSource(config).historicalContext);
+  const [episodeCommentatorModel] = useState<string | null>(() => resolvePgnSource(config).commentatorModel);
+
+  const startedRef = useRef(false);
+  const commentatorAppliedRef = useRef(false);
+
+  // Apply the episode's commentator model id to the replay store
+  // once. Reads existing config via getState() inside the effect so we
+  // don't re-stomp the user's reasoning/verbosity settings on every
+  // store change.
+  useEffect(() => {
+    if (commentatorAppliedRef.current || !episodeCommentatorModel) return;
+    commentatorAppliedRef.current = true;
+    const existing = useTournamentStore.getState().replayCommentatorModel;
+    setReplayCommentatorModel({
+      ...(existing ?? {
+        id: '',
+        name: '',
+        mode: 'llm' as const,
+        reasoningEffort: 'high' as const,
+        maxTokens: 16000,
+        stockfishDepth: 18,
+      }),
+      id: episodeCommentatorModel,
+      name: episodeCommentatorModel,
+      mode: 'llm',
+    });
+  }, [episodeCommentatorModel, setReplayCommentatorModel]);
+
+  // Register bridge hooks so the capture pipeline can drive start/reset.
+  useEffect(() => {
+    exportBridge.__register({
+      start: () => {
+        if (startedRef.current) {
+          console.warn('[BroadcastView] start() called twice; ignoring');
+          return;
+        }
+        if (!pgnText) {
+          console.warn('[BroadcastView] start() before PGN is loaded');
+          return;
+        }
+        startedRef.current = true;
+        startReplay(pgnText, {
+          historicalContext,
+          moveDelayMs: 0,
+          startFromPly: 0,
+        });
+      },
+      reset: () => {
+        startedRef.current = false;
+        if (replayMode) stopReplay();
+      },
+    });
+  }, [pgnText, historicalContext, startReplay, stopReplay, replayMode]);
+
+  useEffect(() => {
+    exportBridge.__markReplayReady(Boolean(pgnText) && !loadError);
+  }, [pgnText, loadError]);
+
+  // Audio readiness: when TTS is disabled the page is trivially
+  // audio-ready. When TTS is enabled the AudioContext is created
+  // lazily by AudioNarrationQueue on first synth; under Chromium with
+  // --autoplay-policy=no-user-gesture-required (the Phase 3 launch
+  // flag) this happens immediately without a user gesture, so we
+  // optimistically signal ready as soon as the bridge is installed.
+  useEffect(() => {
+    exportBridge.__markAudioReady(true);
+  }, [ttsEnabled]);
+
+  // Paint flag: rAF after first React commit guarantees layout is on
+  // screen. Mirrors Clio's painted+mapIdle gate.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => exportBridge.__markPainted());
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  // End flag: replay reaches a terminal status. GameStatus is a
+  // discriminated union — every value except 'created' and
+  // 'in_progress' is terminal.
+  useEffect(() => {
+    if (!activeGameState) return;
+    const status = activeGameState.status;
+    if (status !== 'created' && status !== 'in_progress') {
+      exportBridge.__markEnded();
+    }
+  }, [activeGameState]);
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen bg-surface-0 flex items-center justify-center">
+        <div className="max-w-2xl text-center p-6">
+          <div className="text-red-400 text-lg font-semibold mb-2">Broadcast load error</div>
+          <div className="text-text-secondary text-sm whitespace-pre-wrap">{loadError}</div>
+          <div className="text-text-muted text-xs mt-4">
+            URL params: episode={config.episodeId ?? '(none)'} pgn={config.rawPgn ? 'inline' : '(none)'}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!pgnText) {
+    return (
+      <div className="min-h-screen bg-surface-0 flex items-center justify-center">
+        <div className="text-text-muted text-sm">Loading PGN…</div>
+      </div>
+    );
+  }
+
+  // Once the replay has started, hand off to TournamentProgress which
+  // already owns the full commentary/TTS/board pipeline. Before
+  // start(), show a wait card so the screencast doesn't capture the
+  // landing chrome.
+  if (!replayMode) {
+    return (
+      <div className="min-h-screen bg-surface-0 flex items-center justify-center">
+        <div className="text-text-muted text-sm">Waiting for __CHESS_EXPORT__.start()…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-surface-0 p-3">
+      <TournamentProgress />
+    </div>
+  );
+}
+
+interface ResolvedPgnSource {
+  pgnText: string | null;
+  error: string | null;
+  historicalContext: string | undefined;
+  commentatorModel: string | null;
+}
+
+/**
+ * Resolve a BroadcastConfig to a PGN source, historical context, and
+ * episode commentator model. Pure / synchronous so it can run inside
+ * a useState initializer.
+ */
+function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): ResolvedPgnSource {
+  if (config.rawPgn) {
+    return {
+      pgnText: config.rawPgn,
+      error: null,
+      historicalContext: undefined,
+      commentatorModel: null,
+    };
+  }
+  const episodeId = config.episodeId ?? DEFAULT_EPISODE_ID;
+  if (!episodeId) {
+    return {
+      pgnText: null,
+      error: 'No episode id supplied and no default episode is registered.',
+      historicalContext: undefined,
+      commentatorModel: null,
+    };
+  }
+  const episode = getEpisode(episodeId);
+  if (!episode) {
+    return {
+      pgnText: null,
+      error: `Unknown episode id "${episodeId}". Check src/episodes/registry.ts.`,
+      historicalContext: undefined,
+      commentatorModel: null,
+    };
+  }
+  return {
+    pgnText: episode.pgn,
+    error: null,
+    historicalContext: episode.historicalContext,
+    commentatorModel: episode.commentator.model,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,22 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import { App } from './App'
+import { BroadcastView } from './components/BroadcastView'
+import { getBroadcastConfig } from './app/broadcastConfig'
+import { installExportBridge } from './app/exportBridge'
+
+const broadcastConfig = getBroadcastConfig();
+installExportBridge(broadcastConfig.exportMode);
+
+// Broadcast / MP4-export mode bypasses the normal App tree entirely.
+// The capture pipeline only needs the BroadcastView + tournament store
+// + commentary queue — none of the tabs, ApiKey input, TechDiff
+// overlay, or fullscreen handling apply. Routing here (vs. inside
+// App.tsx) keeps App's hook order stable for the normal SPA case.
+const Root = broadcastConfig.exportMode ? BroadcastView : App;
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Root />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary

First slice of the MP4 game-review export pipeline (#34). Adds the handshake contract a headless-Chromium capture pipeline (Phase 3) needs to deterministically drive a PGN replay and read playback timing back out. Mirrors Clio's `__CLIO_EXPORT__` contract so the lifted capture scaffolding ports cleanly.

### What this adds

- **`src/app/broadcastConfig.ts`** parses URL params once at module load:
  - `?export=1` switches to broadcast layout
  - `?broadcast=1` disables interactive affordances
  - `?episode=<id>` loads from `src/episodes` registry
  - `?pgn=<encoded>` raw PGN bypass
  - `?shortId=<id>` is reserved (no-op until #37)
- **`src/app/exportBridge.ts`** installs `window.__CHESS_EXPORT__` with `reset()`, `start()`, `state()`. `state().segmentTimings` is the per-segment paint-offset map that #35 will populate.
- **`src/components/BroadcastView.tsx`** is the chrome-free, auto-playing layout. Resolves the episode (or inline PGN), registers bridge hooks, kicks off `TournamentProgress` which already owns the full commentary / TTS / board pipeline.
- **`src/main.tsx`** routes the React root to `BroadcastView` when `?export=1` is set, bypassing the normal App tree so its hook order stays stable for the SPA case and none of the non-broadcast init (Tauri TTS sidecar, benchmark store) runs.

### What this deliberately does not do

- No render plan (Phase 2 / #35)
- No Playwright or ffmpeg (Phase 3 / #36)
- No highlight clip detection (Phase 4 / #37)
- `segmentTimings` is always `{}` here; Phase 2 wires the AudioNarrationQueue instrumentation that fills it

### Test plan

- [x] `npm run build` — clean tsc, vite 2.65s
- [x] `npm run lint` — clean on the 4 Phase 1 files
- [ ] Manual: `http://localhost:5173/` shows the normal SPA
- [ ] Manual: `http://localhost:5173/?export=1&broadcast=1` routes to `BroadcastView`
- [ ] Manual: `window.__CHESS_EXPORT__` is present in the broadcast-mode console; `state()` returns a valid object
- [ ] Manual: `window.__CHESS_EXPORT__.start()` begins the Opera Game replay; `state().ended` flips true at checkmate

End-to-end verification lives in Phase 3 (Playwright capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broadcast and export mode for tournament content capture and replay functionality.
  * Integrated export pipeline to support headless browser-based content recording and streaming workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->