### PR TITLE
feat(mp4-export): render plan + segment timing measurement (Phase 2, #35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ src-tauri/target/
 # Local Lichess puzzle database artifacts
 data/raw/
 public/data/lichess-puzzles-1500-plus.json
+
+# Generated MP4-export artifacts
+exports/
+
+# TTS clip cache (content-hashed)
+.tts-cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "tailwindcss": "^4.2.1",
+        "tsx": "^4.22.3",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1"
@@ -4983,6 +4984,509 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "plan:game": "tsx scripts/export-render-plan.ts"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-shell": "^2",
-    "@tailwindcss/typography": "^0.5.19",
     "chess.js": "^1.4.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
@@ -24,9 +25,9 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.2.1",
+    "@tauri-apps/cli": "^2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -37,6 +38,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "tailwindcss": "^4.2.1",
+    "tsx": "^4.22.3",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1"

--- a/scripts/export-render-plan.ts
+++ b/scripts/export-render-plan.ts
@@ -1,0 +1,113 @@
+/**
+ * scripts/export-render-plan.ts — write a render plan JSON for a PGN
+ * or registered episode. Useful for inspecting the plan that the
+ * Phase 3 capture pipeline will execute, and as a smoke test that
+ * createRenderPlanFromPgn handles a given source cleanly.
+ *
+ * Usage:
+ *   npm run plan:game -- --episode <episode-id>
+ *   npm run plan:game -- --pgn <path/to/file.pgn>
+ *   npm run plan:game -- --pgn <path> --out exports/<slug>/render-plan.json
+ *
+ * If neither --episode nor --pgn is supplied, defaults to
+ * DEFAULT_EPISODE_ID from src/episodes.
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CHESS_EPISODES, DEFAULT_EPISODE_ID, getEpisode } from '../src/episodes';
+import { createRenderPlanFromPgn, type RenderPlan } from '../src/production/renderPlan';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..');
+
+interface CliFlags {
+  pgnPath: string | null;
+  episodeId: string | null;
+  outPath: string | null;
+}
+
+function parseFlags(argv: string[]): CliFlags {
+  const flags: CliFlags = { pgnPath: null, episodeId: null, outPath: null };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--pgn') flags.pgnPath = argv[i + 1] ?? null;
+    else if (arg.startsWith('--pgn=')) flags.pgnPath = arg.slice('--pgn='.length);
+    else if (arg === '--episode') flags.episodeId = argv[i + 1] ?? null;
+    else if (arg.startsWith('--episode=')) flags.episodeId = arg.slice('--episode='.length);
+    else if (arg === '--out') flags.outPath = argv[i + 1] ?? null;
+    else if (arg.startsWith('--out=')) flags.outPath = arg.slice('--out='.length);
+  }
+  return flags;
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+
+  let pgnText: string;
+  let title: string;
+  let episodeId: string | undefined;
+  let slug: string;
+
+  if (flags.pgnPath) {
+    const absolute = path.resolve(repoRoot, flags.pgnPath);
+    pgnText = await readFile(absolute, 'utf8');
+    const base = path.basename(absolute, path.extname(absolute));
+    title = base;
+    slug = base.toLowerCase().replace(/[^a-z0-9_-]+/g, '-');
+  } else {
+    const id = flags.episodeId ?? DEFAULT_EPISODE_ID;
+    if (!id) {
+      console.error(
+        `No --pgn or --episode supplied and no default episode is registered. Available episodes:\n  ${
+          CHESS_EPISODES.map((e) => e.id).join('\n  ') || '(none)'
+        }`,
+      );
+      process.exit(1);
+    }
+    const episode = getEpisode(id);
+    if (!episode) {
+      console.error(
+        `Unknown episode id "${id}". Available episodes:\n  ${
+          CHESS_EPISODES.map((e) => e.id).join('\n  ') || '(none)'
+        }`,
+      );
+      process.exit(1);
+    }
+    pgnText = episode.pgn;
+    title = episode.title;
+    episodeId = episode.id;
+    slug = episode.id;
+  }
+
+  const createdAt = new Date().toISOString();
+  const plan: RenderPlan = createRenderPlanFromPgn({
+    id: episodeId ?? `pgn:${slug}`,
+    runId: `run:${slug}:${createdAt}`,
+    title,
+    pgn: pgnText,
+    episodeId,
+    createdAt,
+    outputRoot: 'exports',
+  });
+
+  const outPath = flags.outPath
+    ? path.resolve(repoRoot, flags.outPath)
+    : path.resolve(repoRoot, 'exports', slug, 'render-plan.json');
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(plan, null, 2)}\n`, 'utf8');
+
+  const moveCount = plan.fullEpisode.timeline.filter((t) => t.kind === 'move').length;
+  const commentaryCount = plan.fullEpisode.timeline.filter((t) => t.kind === 'commentary').length;
+  const totalSeconds = plan.fullEpisode.range.endMs / 1000;
+  console.log(`[plan] ${title}`);
+  console.log(`[plan]   ${moveCount} moves, ${commentaryCount} commentary slots`);
+  console.log(`[plan]   planned duration: ${totalSeconds.toFixed(1)}s`);
+  console.log(`[plan]   wrote ${path.relative(repoRoot, outPath)}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/exportBridge.ts
+++ b/src/app/exportBridge.ts
@@ -29,10 +29,24 @@ export interface ExportBridgeState {
   /** GameEnded / GameAborted has fired. */
   ended: boolean;
   /**
-   * Map of timeline-segment-index to milliseconds-since-start(),
-   * populated by AudioNarrationQueue in Phase 2. Empty in Phase 1.
+   * Map of {moveIndex → offsetMs from start()}. Populated by
+   * AudioNarrationQueue when each commentary entry's first sentence
+   * begins playing. Phase 3 uses this to retime the render plan so
+   * composed audio sits at the exact paint moment.
+   *
+   * Keyed by 0-indexed ply (matching AudioNarrationQueue's
+   * maxMoveIndex). The Phase 3 export pipeline calls
+   * retimeRenderPlanWithSegmentTimings(plan, segmentTimings) to map
+   * these back onto plan timeline indices.
    */
   segmentTimings: Record<number, number>;
+  /**
+   * Render plan attached by BroadcastView when start() is called.
+   * Useful for diagnostics; the capture pipeline already has the plan
+   * it built before opening the page, so this field is informational.
+   * Optional to keep the contract backward-compatible with Phase 1.
+   */
+  renderPlan?: unknown;
 }
 
 /**
@@ -59,8 +73,13 @@ export interface ExportBridge {
   __markAudioReady(ready: boolean): void;
   /** Internal: GameEnded / GameAborted fired. */
   __markEnded(): void;
-  /** Internal: AudioNarrationQueue records per-segment paint offset. */
-  __recordSegmentTiming(segmentIndex: number, offsetMs: number): void;
+  /**
+   * Internal: AudioNarrationQueue records per-move paint offset (the
+   * moment commentary for that move began playing).
+   */
+  __recordSegmentTiming(moveIndex: number, offsetMs: number): void;
+  /** Internal: BroadcastView attaches the render plan when start() runs. */
+  __setRenderPlan(plan: unknown): void;
   /** Internal: installExportBridge sets broadcastMode at boot. */
   __setBroadcastMode(value: boolean): void;
 }
@@ -114,8 +133,11 @@ export const exportBridge: ExportBridge = {
   __markEnded() {
     state.ended = true;
   },
-  __recordSegmentTiming(segmentIndex, offsetMs) {
-    state.segmentTimings[segmentIndex] = offsetMs;
+  __recordSegmentTiming(moveIndex, offsetMs) {
+    state.segmentTimings[moveIndex] = offsetMs;
+  },
+  __setRenderPlan(plan) {
+    state.renderPlan = plan;
   },
   __setBroadcastMode(value) {
     state.broadcastMode = value;

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -5,6 +5,8 @@ import { getBroadcastConfig } from '../app/broadcastConfig';
 import { exportBridge } from '../app/exportBridge';
 import { getEpisode, DEFAULT_EPISODE_ID } from '../episodes';
 import { TournamentProgress } from './TournamentProgress';
+import { getActiveAudioNarrationQueue } from '../tts/audio-queue';
+import { createRenderPlanFromPgn, type RenderPlan } from '../production/renderPlan';
 
 /**
  * BroadcastView — the chrome-free, auto-playing layout used by the
@@ -64,6 +66,10 @@ export function BroadcastView() {
   }, [episodeCommentatorModel, setReplayCommentatorModel]);
 
   // Register bridge hooks so the capture pipeline can drive start/reset.
+  // On start(), build a render plan from the PGN, attach it to the
+  // bridge for diagnostics, mark the active audio queue's playback
+  // start time, and wire the segment-start callback so each commentary
+  // entry's first sentence records a paint offset.
   useEffect(() => {
     exportBridge.__register({
       start: () => {
@@ -76,6 +82,29 @@ export function BroadcastView() {
           return;
         }
         startedRef.current = true;
+
+        const config = getBroadcastConfig();
+        const plan: RenderPlan = createRenderPlanFromPgn({
+          id: config.episodeId ?? 'inline-pgn',
+          runId: `run:${Date.now()}`,
+          title: 'Broadcast capture',
+          pgn: pgnText,
+          episodeId: config.episodeId ?? undefined,
+        });
+        exportBridge.__setRenderPlan(plan);
+
+        const audioQueue = getActiveAudioNarrationQueue();
+        if (audioQueue) {
+          audioQueue.markPlaybackStart(performance.now());
+          audioQueue.setSegmentStartCallback((moveIndex, offsetMs) => {
+            exportBridge.__recordSegmentTiming(moveIndex, offsetMs);
+          });
+        } else {
+          console.warn(
+            '[BroadcastView] No active AudioNarrationQueue at start() — segment timings will not be recorded',
+          );
+        }
+
         startReplay(pgnText, {
           historicalContext,
           moveDelayMs: 0,
@@ -84,6 +113,14 @@ export function BroadcastView() {
       },
       reset: () => {
         startedRef.current = false;
+        const audioQueue = getActiveAudioNarrationQueue();
+        if (audioQueue) {
+          // Disable segment-timing emission; markPlaybackStart(0)
+          // sets the gate field to 0 which the queue treats as "not
+          // in broadcast mode."
+          audioQueue.markPlaybackStart(0);
+          audioQueue.setSegmentStartCallback(null);
+        }
         if (replayMode) stopReplay();
       },
     });

--- a/src/components/CommentaryPanel.tsx
+++ b/src/components/CommentaryPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CommentaryEntry } from '../commentary/commentaryQueue';
-import { AudioNarrationQueue, type NarrationMove } from '../tts/audio-queue';
+import { AudioNarrationQueue, registerAudioNarrationQueue, type NarrationMove } from '../tts/audio-queue';
 import { checkTtsHealth, checkCloudTtsHealth, type TtsStatus, type TtsSynthesizeOptions } from '../tts/tts-client';
 import { useSettingsStore } from '../store/settingsStore';
 import { segmentChessMoves } from '../utils/chess-squares';
@@ -76,11 +76,17 @@ export function CommentaryPanel({ entries, commentatorModelName, sessionKey, onN
     registerNarrationGate(() => audioQueueRef.current?.waitUntilDone() ?? Promise.resolve());
     // Register stop callback so aborting/skipping kills audio immediately
     registerNarrationStop(() => audioQueueRef.current?.stop());
+    // Expose this queue to the MP4-export broadcast path so it can
+    // call markPlaybackStart() and setSegmentStartCallback() on the
+    // active instance without reaching into React internals. No-op
+    // outside broadcast mode.
+    registerAudioNarrationQueue(audioQueueRef.current);
     return () => {
       // Stop any playing audio when component unmounts or effect re-runs
       audioQueueRef.current?.stop();
       registerNarrationGate(null);
       registerNarrationStop(null);
+      registerAudioNarrationQueue(null);
     };
   }, [ttsVolume]);
 

--- a/src/production/renderPlan.ts
+++ b/src/production/renderPlan.ts
@@ -1,0 +1,364 @@
+/**
+ * Render plan — the deterministic timeline a capture pipeline replays.
+ *
+ * A render plan describes every move and commentary segment of a game
+ * with a planned start offset and duration. The capture pipeline opens
+ * the SPA in broadcast mode, calls __CHESS_EXPORT__.start(), reads the
+ * actual paint offsets back out as `segmentTimings`, then calls
+ * `retimeRenderPlanWithSegmentTimings` to produce a plan whose
+ * durations match what actually played.
+ *
+ * Shape mirrors Clio's RenderPlan / RenderTarget / TimelineItem
+ * vocabulary so the lifted capture scaffolding (Phase 3) ports
+ * cleanly.
+ */
+
+import { parseSinglePgn, type PgnGame, type PgnMove } from '../pgn/parser';
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type TimelineItemKind = 'move' | 'commentary' | 'gap';
+
+export interface TimelineItem {
+  /** Monotonically increasing across the target's timeline. */
+  index: number;
+  kind: TimelineItemKind;
+  /** Planned start offset within the target, in ms. */
+  startMs: number;
+  /** Planned duration, in ms. Re-measured by the capture pipeline. */
+  durationMs: number;
+  /**
+   * Move index this item belongs to (0-indexed ply). Present on
+   * 'move' and 'commentary' kinds; absent on 'gap'.
+   */
+  moveIndex?: number;
+  /** SAN move text. Present on 'move' and 'commentary' kinds. */
+  sanMove?: string;
+  /** Color whose move this is. Present on 'move' and 'commentary' kinds. */
+  color?: 'w' | 'b';
+  /** FEN after the move. Present on 'move' kind. */
+  fen?: string;
+  /**
+   * Planned commentary text. Present on 'commentary' kind in the
+   * initial plan; replaced with the actual generated text after
+   * playback by the export pipeline. May be empty when the plan is
+   * built before commentary generation runs.
+   */
+  text?: string;
+}
+
+export interface Viewport {
+  width: number;
+  height: number;
+  /** Informational, e.g. '16:9' or '9:16'. */
+  aspectRatio?: string;
+  deviceScaleFactor?: number;
+}
+
+export interface RenderArtifact {
+  fileName: string;
+  durationMs: number;
+}
+
+export type RenderTargetKind = 'full' | 'short';
+
+export interface RenderTarget {
+  id: string;
+  kind: RenderTargetKind;
+  viewport: Viewport;
+  range: {
+    startMs: number;
+    endMs: number;
+    /** Index of the last timeline item included. */
+    endSegmentIndex: number;
+  };
+  timeline: TimelineItem[];
+  artifact: RenderArtifact;
+  outputPath: string;
+  /** Phase 4 only — clip id this short was sliced from. Absent on 'full'. */
+  shortId?: string;
+}
+
+export interface NarrationTiming {
+  /** Per-character TTS speech rate, in ms. ~50 ms ≈ 200 wpm. */
+  textMsPerChar: number;
+  /** Floor duration for a commentary block. */
+  textMinMs: number;
+  /** Ceiling so an outlier doesn't dominate the timeline. */
+  textMaxMs: number;
+  /** Duration of a 'move' segment (board update, brief pause). */
+  moveDurationMs: number;
+  /** Duration of a 'gap' segment between move and commentary. */
+  gapDurationMs: number;
+}
+
+/**
+ * Default narration timing tuned for game-review pacing. Commentary
+ * blocks land in the 4–18 s range; moves get ~1.5 s of board focus
+ * before the narrator starts talking.
+ *
+ * These are PLANNED durations only — the capture pipeline replaces
+ * them with measured durations via retimeRenderPlanWithSegmentTimings.
+ */
+export const NATURAL_NARRATION_TIMING: NarrationTiming = {
+  textMsPerChar: 55,
+  textMinMs: 4_000,
+  textMaxMs: 18_000,
+  moveDurationMs: 1_500,
+  gapDurationMs: 600,
+};
+
+export interface RenderPlan {
+  id: string;
+  runId: string;
+  /** Game-review-specific provenance: episode id when one was selected. */
+  episodeId?: string;
+  title: string;
+  createdAt: string;
+  timing: NarrationTiming;
+  fullEpisode: RenderTarget;
+  /** Phase 4 will populate this from detected highlight clips. */
+  shorts: RenderTarget[];
+  /** Original parsed game for downstream consumers (e.g. retime). */
+  pgnHeaders: Record<string, string | undefined>;
+  /** Optional output root used by CLI scripts. */
+  outputRoot?: string;
+}
+
+// ─── Plan construction ──────────────────────────────────────────────
+
+export interface CreateRenderPlanOptions {
+  id: string;
+  runId: string;
+  title: string;
+  pgn: string;
+  episodeId?: string;
+  createdAt?: string;
+  timing?: NarrationTiming;
+  viewport?: Viewport;
+  outputRoot?: string;
+  /**
+   * Per-move commentary text, keyed by 0-indexed move. When provided,
+   * each commentary item's `text` is filled in and the duration is
+   * estimated from the character count. Otherwise commentary items
+   * carry empty text and the floor duration.
+   */
+  commentaryByMoveIndex?: Record<number, string>;
+}
+
+/**
+ * Build a RenderPlan from a PGN string.
+ *
+ * The resulting plan interleaves move and commentary items in board
+ * order:
+ *
+ *   move 0 → commentary 0 → move 1 → commentary 1 → …
+ *
+ * A small `gap` item between move and commentary lets the board
+ * update animation settle before narration starts.
+ *
+ * Durations are PLANNED estimates; the capture pipeline re-times the
+ * plan from measured segment paint offsets after recording.
+ */
+export function createRenderPlanFromPgn(options: CreateRenderPlanOptions): RenderPlan {
+  const timing = options.timing ?? NATURAL_NARRATION_TIMING;
+  const viewport: Viewport = options.viewport ?? {
+    width: 1920,
+    height: 1080,
+    aspectRatio: '16:9',
+    deviceScaleFactor: 1,
+  };
+  const createdAt = options.createdAt ?? new Date().toISOString();
+  const game = parseSinglePgn(options.pgn);
+
+  const timeline: TimelineItem[] = [];
+  let cursor = 0;
+  let index = 0;
+  game.moves.forEach((move, moveIndex) => {
+    const moveItem: TimelineItem = {
+      index: index++,
+      kind: 'move',
+      startMs: cursor,
+      durationMs: timing.moveDurationMs,
+      moveIndex,
+      sanMove: move.san,
+      color: move.color,
+      fen: move.fen,
+    };
+    timeline.push(moveItem);
+    cursor += moveItem.durationMs;
+
+    const gapItem: TimelineItem = {
+      index: index++,
+      kind: 'gap',
+      startMs: cursor,
+      durationMs: timing.gapDurationMs,
+    };
+    timeline.push(gapItem);
+    cursor += gapItem.durationMs;
+
+    const text = options.commentaryByMoveIndex?.[moveIndex] ?? '';
+    const commentaryItem: TimelineItem = {
+      index: index++,
+      kind: 'commentary',
+      startMs: cursor,
+      durationMs: estimateCommentaryDurationMs(text, timing),
+      moveIndex,
+      sanMove: move.san,
+      color: move.color,
+      text,
+    };
+    timeline.push(commentaryItem);
+    cursor += commentaryItem.durationMs;
+  });
+
+  const lastItem = timeline[timeline.length - 1];
+  const endMs = lastItem ? lastItem.startMs + lastItem.durationMs : 0;
+  const slug = sanitizeSlug(options.episodeId ?? options.id);
+
+  const fullEpisode: RenderTarget = {
+    id: `${options.id}:full`,
+    kind: 'full',
+    viewport,
+    range: {
+      startMs: 0,
+      endMs,
+      endSegmentIndex: lastItem?.index ?? 0,
+    },
+    timeline,
+    artifact: {
+      fileName: `${slug}.mp4`,
+      durationMs: endMs,
+    },
+    outputPath: joinPath(options.outputRoot ?? 'exports', slug, `${slug}.mp4`),
+  };
+
+  return {
+    id: options.id,
+    runId: options.runId,
+    episodeId: options.episodeId,
+    title: options.title,
+    createdAt,
+    timing,
+    fullEpisode,
+    shorts: [],
+    pgnHeaders: { ...game.headers },
+    outputRoot: options.outputRoot,
+  };
+}
+
+function estimateCommentaryDurationMs(text: string, timing: NarrationTiming): number {
+  if (!text) return timing.textMinMs;
+  const estimated = text.length * timing.textMsPerChar;
+  return Math.min(timing.textMaxMs, Math.max(timing.textMinMs, estimated));
+}
+
+// ─── Retiming from measured offsets ─────────────────────────────────
+
+/**
+ * Map of {moveIndex → offsetMs from playback start}, populated by the
+ * broadcast bridge during capture. Keys are 0-indexed plies, matching
+ * the `maxMoveIndex` AudioNarrationQueue records when each commentary
+ * entry's first sentence begins playing.
+ */
+export type SegmentTimingsByMove = Record<number, number>;
+
+/**
+ * Given a render plan and a SegmentTimingsByMove map produced by the
+ * broadcast bridge, produce a new plan whose commentary start offsets
+ * and durations reflect what actually played. Items without a measured
+ * offset keep their planned values, anchored against the previous
+ * measured item where possible.
+ *
+ * The capture pipeline uses the retimed plan when composing the final
+ * audio track — caption / narration alignment within ~50 ms of paint.
+ */
+export function retimeRenderPlanWithSegmentTimings(
+  plan: RenderPlan,
+  timingsByMove: SegmentTimingsByMove,
+): RenderPlan {
+  const retimedTimeline = retimeTimeline(plan.fullEpisode.timeline, timingsByMove);
+  const lastItem = retimedTimeline[retimedTimeline.length - 1];
+  const endMs = lastItem ? lastItem.startMs + lastItem.durationMs : 0;
+  const retimedFull: RenderTarget = {
+    ...plan.fullEpisode,
+    timeline: retimedTimeline,
+    range: {
+      ...plan.fullEpisode.range,
+      endMs,
+      endSegmentIndex: lastItem?.index ?? plan.fullEpisode.range.endSegmentIndex,
+    },
+    artifact: {
+      ...plan.fullEpisode.artifact,
+      durationMs: endMs,
+    },
+  };
+  return {
+    ...plan,
+    fullEpisode: retimedFull,
+  };
+}
+
+function retimeTimeline(timeline: TimelineItem[], timingsByMove: SegmentTimingsByMove): TimelineItem[] {
+  // Anchor commentary items at their measured paint offsets when
+  // available. Move and gap items keep their planned durations but
+  // their startMs slides to sit immediately before the next measured
+  // commentary anchor. This preserves the move-before-commentary
+  // ordering while honoring the real audio clock.
+  //
+  // Walk the timeline once. Track a running cursor that advances by
+  // planned duration; whenever a measured anchor is encountered, snap
+  // the cursor to that anchor (with a sanity floor so we never go
+  // backward).
+  const result: TimelineItem[] = [];
+  let cursor = 0;
+  for (const item of timeline) {
+    const measured = measuredOffsetFor(item, timingsByMove);
+    const startMs = measured !== null ? Math.max(cursor, measured) : cursor;
+    const nextMeasured = findNextMeasuredAfter(timeline, timingsByMove, item.index);
+    const durationMs =
+      nextMeasured !== null && nextMeasured > startMs
+        ? nextMeasured - startMs
+        : item.durationMs;
+    result.push({ ...item, startMs, durationMs });
+    cursor = startMs + durationMs;
+  }
+  return result;
+}
+
+function measuredOffsetFor(item: TimelineItem, timingsByMove: SegmentTimingsByMove): number | null {
+  if (item.kind !== 'commentary' || item.moveIndex === undefined) return null;
+  const measured = timingsByMove[item.moveIndex];
+  return measured !== undefined ? measured : null;
+}
+
+function findNextMeasuredAfter(
+  timeline: TimelineItem[],
+  timingsByMove: SegmentTimingsByMove,
+  afterIndex: number,
+): number | null {
+  for (const item of timeline) {
+    if (item.index <= afterIndex) continue;
+    const measured = measuredOffsetFor(item, timingsByMove);
+    if (measured !== null) return measured;
+  }
+  return null;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function sanitizeSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
+function joinPath(...parts: string[]): string {
+  return parts.filter(Boolean).join('/');
+}
+
+// ─── Public re-exports for downstream consumers ────────────────────
+
+export type { PgnGame, PgnMove };

--- a/src/tts/audio-queue.ts
+++ b/src/tts/audio-queue.ts
@@ -21,10 +21,24 @@ interface QueueEntry {
   entryId?: string;
   maxMoveIndex?: number;
   moves?: NarrationMove[];
+  /**
+   * True when this sentence opens a new commentary entry (i.e. the
+   * board should advance and a render-plan paint offset should be
+   * recorded). Set by enqueueEntry for the first sentence only.
+   */
+  isEntryHead?: boolean;
 }
 
 export type SentenceStartCallback = (text: string, squares: string[], annotations: BoardAnnotations) => void;
 export type EntryStartCallback = (maxMoveIndex: number, moves: NarrationMove[], entryId: string) => void;
+/**
+ * Fires when the first sentence of a commentary entry begins playing.
+ * Receives the move index this entry covers and the offset from
+ * markPlaybackStart() in ms. Used only in broadcast / MP4-export mode.
+ * The export pipeline maps moveIndex → render-plan segment index when
+ * composing audio.
+ */
+export type SegmentStartCallback = (maxMoveIndex: number, offsetMs: number) => void;
 
 /**
  * Sequential audio narration queue with per-sentence board sync.
@@ -49,8 +63,18 @@ export class AudioNarrationQueue {
   private prefetchPromise: Promise<ArrayBuffer> | null = null;
   private onSentenceStart: SentenceStartCallback | null = null;
   private onEntryStart: EntryStartCallback | null = null;
+  private onSegmentStart: SegmentStartCallback | null = null;
   /** Tracks which entryId we last fired onEntryStart for. */
   private _lastFiredEntryId: string | null = null;
+  /**
+   * performance.now() at which __CHESS_EXPORT__.start() was called.
+   * Used to compute per-segment paint offsets in broadcast / MP4-export
+   * mode. Zero when not in broadcast mode (and onSegmentStart never
+   * fires).
+   */
+  private playbackStartMs = 0;
+  /** Tracks which moveIndex we last fired onSegmentStart for. */
+  private _lastFiredSegmentMoveIndex = -1;
 
   /** Number of commentary entries waiting or being played. */
   private _entryCount = 0;
@@ -87,6 +111,33 @@ export class AudioNarrationQueue {
   }
 
   /**
+   * Set callback fired when a sentence belonging to a known render-plan
+   * segment begins audio playback. Receives the segment index and the
+   * offset from markPlaybackStart() in ms.
+   *
+   * Used only in broadcast / MP4-export mode (Phase 2). The capture
+   * pipeline reads these offsets back through __CHESS_EXPORT__.state()
+   * and re-times the render plan so composed narration audio sits at
+   * the exact paint moment.
+   */
+  setSegmentStartCallback(cb: SegmentStartCallback | null): void {
+    this.onSegmentStart = cb;
+  }
+
+  /**
+   * Mark the moment __CHESS_EXPORT__.start() was called. All subsequent
+   * onSegmentStart offsets are measured from this point.
+   *
+   * No-op outside broadcast mode. Calling again with 0 disables segment
+   * timing emission for the rest of the queue's lifetime (used by the
+   * reset path).
+   */
+  markPlaybackStart(performanceNow: number): void {
+    this.playbackStartMs = performanceNow;
+    this._lastFiredSegmentMoveIndex = -1;
+  }
+
+  /**
    * Enqueue a full commentary entry with board-sync metadata.
    * Board advances only when this entry's first sentence starts playing.
    */
@@ -99,6 +150,7 @@ export class AudioNarrationQueue {
     const cleanText = stripMarkdownForTts(text);
     const sentences = splitIntoSentences(cleanText);
     this._entryCount++;
+    let firstSentenceOfEntry = true;
     for (const sentence of sentences) {
       const trimmed = sentence.trim();
       if (trimmed) {
@@ -115,7 +167,12 @@ export class AudioNarrationQueue {
           entryId: options.entryId,
           maxMoveIndex: options.maxMoveIndex,
           moves: options.moves,
+          // Only the first sentence of an entry is treated as the
+          // "head" — that's where the board advances and where the
+          // export pipeline records the segment paint offset.
+          isEntryHead: firstSentenceOfEntry,
         });
+        firstSentenceOfEntry = false;
       }
     }
     this.ensureProcessing();
@@ -304,6 +361,23 @@ export class AudioNarrationQueue {
         // Fire sentence start callback right before playback
         this.onSentenceStart?.(entry.text, entry.squares, entry.annotations);
 
+        // Fire segment-start callback when this sentence opens a new
+        // commentary entry AND we're in broadcast mode (markPlaybackStart
+        // has been called with a non-zero performance.now). Recorded
+        // once per moveIndex; the commentary entry's first sentence wins.
+        if (
+          entry.isEntryHead
+          && entry.maxMoveIndex !== undefined
+          && this.playbackStartMs > 0
+          && entry.maxMoveIndex !== this._lastFiredSegmentMoveIndex
+        ) {
+          this._lastFiredSegmentMoveIndex = entry.maxMoveIndex;
+          this.onSegmentStart?.(
+            entry.maxMoveIndex,
+            performance.now() - this.playbackStartMs,
+          );
+        }
+
         // Play the audio
         await this.playAudioBuffer(audioData);
       } catch (err) {
@@ -372,6 +446,31 @@ function stripMarkdownForTts(text: string): string {
     .replace(/\n{2,}/g, ' ')
     .replace(/\s{2,}/g, ' ')
     .trim();
+}
+
+// ─── Active-queue registry (broadcast mode) ─────────────────────────
+//
+// CommentaryPanel creates an AudioNarrationQueue per session. The
+// MP4-export pipeline (BroadcastView in Phase 1, scripts/lib/export in
+// Phase 3) needs to reach the currently-active queue to call
+// markPlaybackStart() and setSegmentStartCallback(). Following the
+// existing registerCommentaryQueue pattern in tournamentStore, expose
+// a module-level slot. Outside broadcast mode this slot is set but
+// nobody reads it.
+
+let activeAudioNarrationQueue: AudioNarrationQueue | null = null;
+
+/**
+ * Register the audio narration queue currently driving playback. Called
+ * by CommentaryPanel on mount. Unregister with null on unmount.
+ */
+export function registerAudioNarrationQueue(queue: AudioNarrationQueue | null): void {
+  activeAudioNarrationQueue = queue;
+}
+
+/** Returns the active audio narration queue, if any. */
+export function getActiveAudioNarrationQueue(): AudioNarrationQueue | null {
+  return activeAudioNarrationQueue;
 }
 
 /**


### PR DESCRIPTION
## Summary

Second slice of the MP4 game-review export pipeline (#35). Stacks on #38.

Adds the deterministic timeline a capture pipeline replays, and instruments `AudioNarrationQueue` so the broadcast bridge records the real paint moment of each commentary entry. Phase 3 uses those measured offsets to keep composed narration audio aligned to captions within ~50 ms.

### What this adds

- **`src/production/renderPlan.ts`** — `RenderPlan` / `RenderTarget` / `TimelineItem` (`move` | `commentary` | `gap`) per Clio's vocabulary, plus `createRenderPlanFromPgn()` and `retimeRenderPlanWithSegmentTimings()`. Default `NarrationTiming` tuned for game-review pacing (4–18 s commentary blocks, 1.5 s move display, 0.6 s gap).
- **`src/tts/audio-queue.ts`**
  - new `SegmentStartCallback` signature `(maxMoveIndex, offsetMs)`
  - `markPlaybackStart(performanceNow)` anchors the offset clock; zero disables emission
  - `QueueEntry.isEntryHead` replaces ad-hoc first-sentence detection
  - `registerAudioNarrationQueue` / `getActiveAudioNarrationQueue` — module-level registry following the existing `registerCommentaryQueue` / `registerNarrationGate` pattern, so the broadcast path can reach the active queue without React refs
  - Emit per-segment offsets at the same instant `onSentenceStart` fires; recorded once per `moveIndex` (entry head wins)
- **`src/components/CommentaryPanel.tsx`** — register the audio queue on mount, unregister on unmount. No-op outside broadcast mode.
- **`src/components/BroadcastView.tsx`** — on bridge `start()`, build the render plan, attach to bridge (diagnostics), mark playback start on the active audio queue, and wire the segment-start callback to `exportBridge.__recordSegmentTiming`.
- **`src/app/exportBridge.ts`** — `segmentTimings` is now `Record<moveIndex, offsetMs>`; new `__setRenderPlan` internal hook + `state.renderPlan` field for diagnostics.
- **`scripts/export-render-plan.ts`** + `npm run plan:game` — generate a `render-plan.json` for any PGN or registered episode. Smoke-tests `createRenderPlanFromPgn` end-to-end.
- **`.gitignore`** — `exports/` and `.tts-cache/`.
- **`package.json`** — `tsx ^4.20` as devDependency for the CLI.

### Smoke test

```
$ npm run plan:game
[plan] The Opera Game — Morphy vs Brunswick and Isouard, 1858
[plan]   33 moves, 33 commentary slots
[plan]   planned duration: 201.3s
[plan]   wrote exports/opera_game_morphy_1858/render-plan.json
```

### What this deliberately does not do

- No Playwright / ffmpeg — that's #36
- No highlight clip detection — that's #37
- Doesn't *prove* segment timings work end-to-end; end-to-end verification happens in Phase 3 (capture pipeline reads `__CHESS_EXPORT__.state().segmentTimings` and runs `retimeRenderPlanWithSegmentTimings`)

### Test plan

- [x] `npm run build` — clean tsc, vite 2.67s
- [x] `npm run plan:game` — produces a valid `render-plan.json` (33 moves)
- [x] `npm run lint` on Phase 2 files — clean (3 pre-existing warnings in `CommentaryPanel` are unrelated)
- [ ] Manual: `?export=1&broadcast=1&episode=opera_game_morphy_1858` → bridge `start()` calls `markPlaybackStart`; opening console and inspecting `__CHESS_EXPORT__.state().segmentTimings` after a few moves shows `{ 0: <ms>, 1: <ms>, … }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
