### PR TITLE
feat(mp4-export): Playwright capture + ffmpeg compose pipeline (Phase 3, #36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ src-tauri/target/
 # Local Lichess puzzle database artifacts
 data/raw/
 public/data/lichess-puzzles-1500-plus.json
+
+# Generated MP4-export artifacts
+exports/
+
+# TTS clip cache (content-hashed)
+.tts-cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,9 @@
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
+        "ffmpeg-static": "^5.3.0",
         "globals": "^16.5.0",
+        "playwright": "^1.60.0",
         "tailwindcss": "^4.2.1",
         "tsx": "^4.22.3",
         "typescript": "~5.9.3",
@@ -319,6 +321,22 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2386,6 +2404,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2501,6 +2532,13 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2531,6 +2569,13 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2641,6 +2686,22 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2770,6 +2831,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/esbuild": {
@@ -3076,6 +3147,23 @@
         }
       }
     },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3262,6 +3350,37 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3298,6 +3417,13 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -4516,6 +4642,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -4581,6 +4713,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -4631,6 +4810,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/property-information": {
@@ -4709,6 +4898,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/remark-parse": {
@@ -4799,6 +5003,27 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4856,6 +5081,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/stringify-entities": {
@@ -5501,6 +5736,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "tailwindcss": "^4.2.1",
+        "tsx": "^4.22.3",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1"
@@ -4983,6 +4984,509 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
-    "plan:game": "tsx scripts/export-render-plan.ts"
+    "plan:game": "tsx scripts/export-render-plan.ts",
+    "export:game": "tsx scripts/export-chess-mp4.ts"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
@@ -36,7 +37,9 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "ffmpeg-static": "^5.3.0",
     "globals": "^16.5.0",
+    "playwright": "^1.60.0",
     "tailwindcss": "^4.2.1",
     "tsx": "^4.22.3",
     "typescript": "~5.9.3",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "plan:game": "tsx scripts/export-render-plan.ts"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-shell": "^2",
-    "@tailwindcss/typography": "^0.5.19",
     "chess.js": "^1.4.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
@@ -24,9 +25,9 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.2.1",
+    "@tauri-apps/cli": "^2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -37,6 +38,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "tailwindcss": "^4.2.1",
+    "tsx": "^4.22.3",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1"

--- a/scripts/export-chess-mp4.ts
+++ b/scripts/export-chess-mp4.ts
@@ -1,0 +1,238 @@
+/**
+ * scripts/export-chess-mp4.ts — produce a playable MP4 of any
+ * registered episode (or inline PGN) via headless-Chromium capture.
+ *
+ * Usage:
+ *   npm run export:game                                 # default episode
+ *   npm run export:game -- --episode opera_game_morphy_1858
+ *   npm run export:game -- --pgn matches/some.pgn
+ *   npm run export:game -- --episode <id> --fast
+ *   npm run export:game -- --episode <id> --preview=30
+ *   npm run export:game -- --episode <id> --keep-frames
+ *
+ * Output:
+ *   exports/<slug>/<slug>.mp4
+ *   exports/<slug>/render-plan.json      (retimed with measured offsets)
+ *   exports/<slug>/render-manifest.json  (frame count, durations, console errors)
+ *
+ * Phase 3 produces a SILENT mp4. Audio mux lands as a Phase 3.1
+ * follow-up — the SPA plays TTS live during capture, but CDP
+ * screencast does not capture audio. The render-plan.json + segment
+ * timings preserve everything the audio composition step needs.
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ffmpegStatic from 'ffmpeg-static';
+import { CHESS_EPISODES, DEFAULT_EPISODE_ID, getEpisode } from '../src/episodes';
+import {
+  createRenderPlanFromPgn,
+  retimeRenderPlanWithSegmentTimings,
+  type RenderPlan,
+} from '../src/production/renderPlan';
+import {
+  cleanupFrames,
+  launchBrowser,
+  recordBroadcastPlayback,
+} from './lib/export/browserCapture';
+import { startViteServer } from './lib/export/devServer';
+import { composeMp4 } from './lib/export/ffmpegCompose';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..');
+
+interface CliFlags {
+  pgnPath: string | null;
+  episodeId: string | null;
+  fastMode: boolean;
+  previewDurationMs: number | null;
+  keepFrames: boolean;
+  outputRoot: string;
+}
+
+function parseFlags(argv: string[]): CliFlags {
+  const flags: CliFlags = {
+    pgnPath: null,
+    episodeId: null,
+    fastMode: false,
+    previewDurationMs: null,
+    keepFrames: false,
+    outputRoot: 'exports',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--pgn') flags.pgnPath = argv[i + 1] ?? null;
+    else if (arg.startsWith('--pgn=')) flags.pgnPath = arg.slice('--pgn='.length);
+    else if (arg === '--episode') flags.episodeId = argv[i + 1] ?? null;
+    else if (arg.startsWith('--episode=')) flags.episodeId = arg.slice('--episode='.length);
+    else if (arg === '--fast') flags.fastMode = true;
+    else if (arg.startsWith('--preview=')) {
+      const sec = Number(arg.slice('--preview='.length));
+      if (Number.isFinite(sec) && sec > 0) flags.previewDurationMs = Math.round(sec * 1000);
+    } else if (arg === '--preview') {
+      const sec = Number(argv[i + 1]);
+      if (Number.isFinite(sec) && sec > 0) flags.previewDurationMs = Math.round(sec * 1000);
+    } else if (arg === '--keep-frames') flags.keepFrames = true;
+    else if (arg.startsWith('--output-root=')) flags.outputRoot = arg.slice('--output-root='.length);
+  }
+  return flags;
+}
+
+interface ResolvedInput {
+  pgnText: string;
+  title: string;
+  slug: string;
+  episodeId?: string;
+}
+
+async function resolveInput(flags: CliFlags): Promise<ResolvedInput> {
+  if (flags.pgnPath) {
+    const absolute = path.resolve(repoRoot, flags.pgnPath);
+    const pgnText = await readFile(absolute, 'utf8');
+    const base = path.basename(absolute, path.extname(absolute));
+    return {
+      pgnText,
+      title: base,
+      slug: base.toLowerCase().replace(/[^a-z0-9_-]+/g, '-'),
+    };
+  }
+  const id = flags.episodeId ?? DEFAULT_EPISODE_ID;
+  if (!id) {
+    throw new Error(
+      `No --pgn or --episode supplied and no default episode is registered. Available:\n  ${
+        CHESS_EPISODES.map((e) => e.id).join('\n  ') || '(none)'
+      }`,
+    );
+  }
+  const episode = getEpisode(id);
+  if (!episode) {
+    throw new Error(
+      `Unknown episode id "${id}". Available:\n  ${CHESS_EPISODES.map((e) => e.id).join('\n  ') || '(none)'}`,
+    );
+  }
+  return {
+    pgnText: episode.pgn,
+    title: episode.title,
+    slug: episode.id,
+    episodeId: episode.id,
+  };
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+  const ffmpegPath = ffmpegStatic;
+  if (!ffmpegPath) {
+    throw new Error('ffmpeg-static did not resolve a binary path');
+  }
+  const input = await resolveInput(flags);
+  const slug = input.slug;
+  const createdAt = new Date().toISOString();
+
+  // Initial plan — planned durations only. Retimed after capture.
+  const initialPlan: RenderPlan = createRenderPlanFromPgn({
+    id: input.episodeId ?? `pgn:${slug}`,
+    runId: `run:${slug}:${createdAt}`,
+    title: input.title,
+    pgn: input.pgnText,
+    episodeId: input.episodeId,
+    createdAt,
+    outputRoot: flags.outputRoot,
+  });
+  const viewport = {
+    width: initialPlan.fullEpisode.viewport.width,
+    height: initialPlan.fullEpisode.viewport.height,
+    deviceScaleFactor: initialPlan.fullEpisode.viewport.deviceScaleFactor ?? 1,
+  };
+
+  // Working dirs.
+  const outDir = path.resolve(repoRoot, flags.outputRoot, slug);
+  const frameDir = path.resolve(repoRoot, '.tmp', 'export-frames', `${slug}-${Date.now().toString(36)}`);
+  await mkdir(outDir, { recursive: true });
+
+  console.log(`[export] ${input.title}`);
+  console.log(
+    `[export]   ${initialPlan.fullEpisode.timeline.length} segments, planned ${(initialPlan.fullEpisode.range.endMs / 1000).toFixed(1)} s, viewport ${viewport.width}x${viewport.height}`,
+  );
+  if (flags.fastMode) console.log('[export]   --fast (lower JPEG quality)');
+  if (flags.previewDurationMs) console.log(`[export]   --preview=${flags.previewDurationMs / 1000} s`);
+
+  let server: Awaited<ReturnType<typeof startViteServer>> | undefined;
+  let browser: Awaited<ReturnType<typeof launchBrowser>> | undefined;
+  try {
+    server = await startViteServer(repoRoot, '127.0.0.1', 5173);
+    console.log(`[export] vite ready at ${server.url}`);
+    browser = await launchBrowser();
+    console.log('[export] chromium launched');
+
+    const capture = await recordBroadcastPlayback(browser, {
+      serverUrl: server.url,
+      episodeId: input.episodeId,
+      rawPgn: input.episodeId ? undefined : input.pgnText,
+      frameDir,
+      viewport,
+      fastMode: flags.fastMode,
+      previewDurationMs: flags.previewDurationMs ?? undefined,
+    });
+
+    const retimedPlan = retimeRenderPlanWithSegmentTimings(initialPlan, capture.segmentTimings);
+    let outputPath = path.resolve(repoRoot, retimedPlan.fullEpisode.outputPath);
+    if (flags.previewDurationMs) {
+      outputPath = outputPath.replace(/\.mp4$/, '_preview.mp4');
+    }
+
+    await composeMp4({
+      frameDir: capture.frameDir,
+      frameRate: capture.frameRate,
+      outputPath,
+      ffmpegPath,
+    });
+
+    // Sidecar manifests.
+    await writeFile(
+      path.join(outDir, 'render-plan.json'),
+      `${JSON.stringify(retimedPlan, null, 2)}\n`,
+      'utf8',
+    );
+    await writeFile(
+      path.join(outDir, 'render-manifest.json'),
+      `${JSON.stringify(
+        {
+          slug,
+          title: input.title,
+          episodeId: input.episodeId,
+          createdAt,
+          outputPath: path.relative(repoRoot, outputPath),
+          fastMode: flags.fastMode,
+          previewDurationMs: flags.previewDurationMs,
+          capture: {
+            frameCount: capture.frameCount,
+            frameRate: capture.frameRate,
+            durationMs: capture.durationMs,
+            segmentTimingsCount: Object.keys(capture.segmentTimings).length,
+          },
+          consoleEntries: capture.consoleEntries.slice(-30),
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    console.log(`[export] wrote ${path.relative(repoRoot, outputPath)}`);
+    console.log(`[export] wrote ${path.relative(repoRoot, path.join(outDir, 'render-plan.json'))}`);
+    console.log(`[export] wrote ${path.relative(repoRoot, path.join(outDir, 'render-manifest.json'))}`);
+  } finally {
+    await Promise.allSettled([
+      browser?.close(),
+      server?.stop(),
+      cleanupFrames(frameDir, flags.keepFrames),
+    ]);
+  }
+}
+
+main().catch((err) => {
+  console.error('[export] failed:', err instanceof Error ? err.message : err);
+  if (err instanceof Error && err.stack) console.error(err.stack);
+  process.exit(1);
+});

--- a/scripts/export-render-plan.ts
+++ b/scripts/export-render-plan.ts
@@ -1,0 +1,113 @@
+/**
+ * scripts/export-render-plan.ts — write a render plan JSON for a PGN
+ * or registered episode. Useful for inspecting the plan that the
+ * Phase 3 capture pipeline will execute, and as a smoke test that
+ * createRenderPlanFromPgn handles a given source cleanly.
+ *
+ * Usage:
+ *   npm run plan:game -- --episode <episode-id>
+ *   npm run plan:game -- --pgn <path/to/file.pgn>
+ *   npm run plan:game -- --pgn <path> --out exports/<slug>/render-plan.json
+ *
+ * If neither --episode nor --pgn is supplied, defaults to
+ * DEFAULT_EPISODE_ID from src/episodes.
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CHESS_EPISODES, DEFAULT_EPISODE_ID, getEpisode } from '../src/episodes';
+import { createRenderPlanFromPgn, type RenderPlan } from '../src/production/renderPlan';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..');
+
+interface CliFlags {
+  pgnPath: string | null;
+  episodeId: string | null;
+  outPath: string | null;
+}
+
+function parseFlags(argv: string[]): CliFlags {
+  const flags: CliFlags = { pgnPath: null, episodeId: null, outPath: null };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--pgn') flags.pgnPath = argv[i + 1] ?? null;
+    else if (arg.startsWith('--pgn=')) flags.pgnPath = arg.slice('--pgn='.length);
+    else if (arg === '--episode') flags.episodeId = argv[i + 1] ?? null;
+    else if (arg.startsWith('--episode=')) flags.episodeId = arg.slice('--episode='.length);
+    else if (arg === '--out') flags.outPath = argv[i + 1] ?? null;
+    else if (arg.startsWith('--out=')) flags.outPath = arg.slice('--out='.length);
+  }
+  return flags;
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+
+  let pgnText: string;
+  let title: string;
+  let episodeId: string | undefined;
+  let slug: string;
+
+  if (flags.pgnPath) {
+    const absolute = path.resolve(repoRoot, flags.pgnPath);
+    pgnText = await readFile(absolute, 'utf8');
+    const base = path.basename(absolute, path.extname(absolute));
+    title = base;
+    slug = base.toLowerCase().replace(/[^a-z0-9_-]+/g, '-');
+  } else {
+    const id = flags.episodeId ?? DEFAULT_EPISODE_ID;
+    if (!id) {
+      console.error(
+        `No --pgn or --episode supplied and no default episode is registered. Available episodes:\n  ${
+          CHESS_EPISODES.map((e) => e.id).join('\n  ') || '(none)'
+        }`,
+      );
+      process.exit(1);
+    }
+    const episode = getEpisode(id);
+    if (!episode) {
+      console.error(
+        `Unknown episode id "${id}". Available episodes:\n  ${
+          CHESS_EPISODES.map((e) => e.id).join('\n  ') || '(none)'
+        }`,
+      );
+      process.exit(1);
+    }
+    pgnText = episode.pgn;
+    title = episode.title;
+    episodeId = episode.id;
+    slug = episode.id;
+  }
+
+  const createdAt = new Date().toISOString();
+  const plan: RenderPlan = createRenderPlanFromPgn({
+    id: episodeId ?? `pgn:${slug}`,
+    runId: `run:${slug}:${createdAt}`,
+    title,
+    pgn: pgnText,
+    episodeId,
+    createdAt,
+    outputRoot: 'exports',
+  });
+
+  const outPath = flags.outPath
+    ? path.resolve(repoRoot, flags.outPath)
+    : path.resolve(repoRoot, 'exports', slug, 'render-plan.json');
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(plan, null, 2)}\n`, 'utf8');
+
+  const moveCount = plan.fullEpisode.timeline.filter((t) => t.kind === 'move').length;
+  const commentaryCount = plan.fullEpisode.timeline.filter((t) => t.kind === 'commentary').length;
+  const totalSeconds = plan.fullEpisode.range.endMs / 1000;
+  console.log(`[plan] ${title}`);
+  console.log(`[plan]   ${moveCount} moves, ${commentaryCount} commentary slots`);
+  console.log(`[plan]   planned duration: ${totalSeconds.toFixed(1)}s`);
+  console.log(`[plan]   wrote ${path.relative(repoRoot, outPath)}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lib/export/browserCapture.ts
+++ b/scripts/lib/export/browserCapture.ts
@@ -1,0 +1,250 @@
+/**
+ * Drive the SPA's broadcast mode from headless Chromium and capture
+ * frames via CDP Page.startScreencast.
+ *
+ * Lifted from Clio's scripts/lib/export/browserCapture.ts with a
+ * narrower surface:
+ *   - single viewport (no map prewarm, no basemap dance)
+ *   - single TTS provider hook (cloud Qwen / local Python server)
+ *   - chess-specific bridge name (__CHESS_EXPORT__)
+ */
+
+import { mkdir, rm } from 'node:fs/promises';
+import { chromium, type Browser, type Page } from 'playwright';
+import { registerPid } from './processRegistry';
+import { FrameSequenceWriter } from './frameSequenceWriter';
+
+const DEFAULT_FRAME_RATE = 30;
+const SCREENCAST_QUALITY_DEFAULT = 84;
+const SCREENCAST_QUALITY_FAST = 60;
+const EXPORT_READY_TIMEOUT_MS = 180_000;
+const CAPTURE_POSTROLL_MS = 500;
+
+export interface CaptureOptions {
+  /** Vite server URL, e.g. http://127.0.0.1:5173 */
+  serverUrl: string;
+  /** Episode id passed as ?episode=<id>. */
+  episodeId?: string;
+  /** Inline PGN passed as ?pgn=<encoded>. Mutually exclusive with episodeId. */
+  rawPgn?: string;
+  /** Output frame dir (absolute path). Will be created. */
+  frameDir: string;
+  /** Viewport for the capture. */
+  viewport: { width: number; height: number; deviceScaleFactor?: number };
+  /** Iteration / preview mode — lowers JPEG quality. */
+  fastMode?: boolean;
+  /**
+   * Optional hard cap on capture wall time. If set, capture stops at
+   * this duration regardless of whether the game has ended.
+   */
+  previewDurationMs?: number;
+  /**
+   * Maximum time to wait for state().ended before timing out.
+   * Defaults to plannedDurationMs * 1.5 + 5 minutes if not set.
+   */
+  endTimeoutMs?: number;
+}
+
+export interface CaptureResult {
+  frameDir: string;
+  frameCount: number;
+  frameRate: number;
+  /** Wall-clock duration of the recording, ms. */
+  durationMs: number;
+  /** Map of moveIndex → ms-from-start when each commentary entry began playing. */
+  segmentTimings: Record<number, number>;
+  /** Browser console errors / warnings collected during the run. */
+  consoleEntries: BrowserConsoleEntry[];
+}
+
+export interface BrowserConsoleEntry {
+  type: string;
+  text: string;
+}
+
+export async function recordBroadcastPlayback(browser: Browser, options: CaptureOptions): Promise<CaptureResult> {
+  await mkdir(options.frameDir, { recursive: true });
+  const context = await browser.newContext({
+    viewport: { width: options.viewport.width, height: options.viewport.height },
+    deviceScaleFactor: options.viewport.deviceScaleFactor ?? 1,
+    colorScheme: 'dark',
+    reducedMotion: 'no-preference',
+  });
+  const page = await context.newPage();
+  const consoleEntries: BrowserConsoleEntry[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error' || message.type() === 'warning') {
+      consoleEntries.push({ type: message.type(), text: message.text() });
+    }
+  });
+  page.on('pageerror', (error) => {
+    const stack = error.stack && error.stack !== error.message ? `\n${error.stack}` : '';
+    consoleEntries.push({ type: 'pageerror', text: `${error.message}${stack}` });
+  });
+
+  try {
+    const url = buildUrl(options);
+    console.log(`[capture] opening ${url} at ${options.viewport.width}x${options.viewport.height}`);
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: EXPORT_READY_TIMEOUT_MS });
+    await waitForExportBridge(page);
+
+    // Bridge is ready; reset state and prepare frame writer.
+    await page.evaluate(() => window.__CHESS_EXPORT__?.reset());
+    await page.waitForTimeout(250);
+
+    const frameWriter = new FrameSequenceWriter({
+      frameDir: options.frameDir,
+      frameRate: DEFAULT_FRAME_RATE,
+    });
+
+    const client = await context.newCDPSession(page);
+    client.on('Page.screencastFrame', (event) => {
+      frameWriter.ingest(event.data, Date.now());
+      void client.send('Page.screencastFrameAck', { sessionId: event.sessionId }).catch(() => undefined);
+    });
+    await client.send('Page.startScreencast', {
+      format: 'jpeg',
+      quality: options.fastMode ? SCREENCAST_QUALITY_FAST : SCREENCAST_QUALITY_DEFAULT,
+      everyNthFrame: 1,
+    });
+
+    const startedAtMs = Date.now();
+    frameWriter.start(startedAtMs);
+    await page.evaluate(() => window.__CHESS_EXPORT__?.start());
+    console.log('[capture] recording started');
+
+    await waitForPlaybackEnd(page, options);
+    const endedAtMs = Date.now();
+    await page.waitForTimeout(CAPTURE_POSTROLL_MS);
+    await client.send('Page.stopScreencast').catch(() => undefined);
+
+    const durationMs = Math.max(1000, endedAtMs - startedAtMs);
+    const frameCount = await frameWriter.finalize(durationMs);
+
+    // Read segment timings + render plan diagnostic back out.
+    const segmentTimings =
+      (await page
+        .evaluate(() => window.__CHESS_EXPORT__?.state().segmentTimings ?? {})
+        .catch(() => ({}))) ?? {};
+
+    console.log(
+      `[capture] captured ${frameCount} frames in ${(durationMs / 1000).toFixed(1)} s, ${
+        Object.keys(segmentTimings).length
+      } segment timings`,
+    );
+    if (Object.keys(segmentTimings).length === 0) {
+      console.warn(
+        '[capture] no segment timings captured — audio will use planned offsets (may drift); is TTS enabled in the SPA settings?',
+      );
+    }
+
+    return {
+      frameDir: options.frameDir,
+      frameCount,
+      frameRate: DEFAULT_FRAME_RATE,
+      durationMs,
+      segmentTimings,
+      consoleEntries,
+    };
+  } finally {
+    await context.close().catch(() => undefined);
+  }
+}
+
+function buildUrl(options: CaptureOptions): string {
+  const url = new URL(options.serverUrl);
+  url.searchParams.set('export', '1');
+  url.searchParams.set('broadcast', '1');
+  if (options.episodeId) url.searchParams.set('episode', options.episodeId);
+  if (options.rawPgn) url.searchParams.set('pgn', options.rawPgn);
+  url.searchParams.set('w', String(options.viewport.width));
+  url.searchParams.set('h', String(options.viewport.height));
+  return url.toString();
+}
+
+async function waitForExportBridge(page: Page): Promise<void> {
+  // Steady-state gate: bridge installed, page mounted, painted at
+  // least once, audio context ready, replay runtime ready.
+  await page.waitForFunction(
+    () => {
+      const bridge = window.__CHESS_EXPORT__;
+      if (!bridge) return false;
+      const state = bridge.state();
+      return state.ready && state.broadcastMode && state.painted && state.replayReady && state.audioReady;
+    },
+    undefined,
+    { timeout: EXPORT_READY_TIMEOUT_MS },
+  );
+}
+
+async function waitForPlaybackEnd(page: Page, options: CaptureOptions): Promise<void> {
+  if (options.previewDurationMs !== undefined) {
+    // Preview mode races a hard cap against the natural end signal.
+    const donePromise = page
+      .waitForFunction(() => Boolean(window.__CHESS_EXPORT__?.state().ended), undefined, {
+        timeout: options.previewDurationMs + 60_000,
+      })
+      .catch(() => undefined);
+    await Promise.race([donePromise, page.waitForTimeout(options.previewDurationMs)]);
+    return;
+  }
+  // Game-review captures: be generous with the timeout. A Morphy
+  // game is ~3 minutes of moves but commentary at high reasoning
+  // effort can easily push 30 minutes. The default 60-minute ceiling
+  // is intentionally large; override via endTimeoutMs.
+  const timeout = options.endTimeoutMs ?? 60 * 60_000;
+  await page.waitForFunction(
+    () => Boolean(window.__CHESS_EXPORT__?.state().ended),
+    undefined,
+    { timeout },
+  );
+}
+
+export async function launchBrowser(): Promise<Browser> {
+  const args = [
+    '--autoplay-policy=no-user-gesture-required',
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+    '--hide-scrollbars',
+  ];
+  const browser = await chromium.launch({ headless: true, args });
+  try {
+    const proc = (browser as unknown as { process?: () => { pid?: number } | null }).process?.();
+    if (proc?.pid !== undefined) {
+      const unregister = registerPid(proc.pid);
+      browser.once('disconnected', unregister);
+    }
+  } catch {
+    // chromium-headless-shell sometimes doesn't expose process(); the
+    // browser still works, we just lose the tree-kill safety net for
+    // the chromium subtree. browser.close() in the orchestrator's
+    // finally block remains the primary cleanup.
+  }
+  return browser;
+}
+
+export async function cleanupFrames(frameDir: string, keep: boolean): Promise<void> {
+  if (keep) return;
+  await rm(frameDir, { recursive: true, force: true });
+}
+
+// Augment the window type for TS callers inside page.evaluate().
+declare global {
+  interface Window {
+    __CHESS_EXPORT__?: {
+      reset(): void;
+      start(): void;
+      state(): {
+        ready: boolean;
+        painted: boolean;
+        broadcastMode: boolean;
+        replayReady: boolean;
+        audioReady: boolean;
+        ended: boolean;
+        segmentTimings: Record<number, number>;
+        renderPlan?: unknown;
+      };
+    };
+  }
+}

--- a/scripts/lib/export/devServer.ts
+++ b/scripts/lib/export/devServer.ts
@@ -1,0 +1,136 @@
+/**
+ * Spawn Vite directly so tree-kill works on Windows.
+ *
+ * `npm run dev` wraps Vite in npm.cmd → node, which on Windows
+ * orphans children when the parent is killed. Spawning vite.js
+ * directly via Node keeps the process tree under our control so
+ * Ctrl+C / signal handlers can clean up reliably.
+ *
+ * Adapted from Clio's scripts/lib/export/devServer.ts with a
+ * narrower surface — we only need a single instance per export run.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { registerPid } from './processRegistry';
+
+export interface ViteServer {
+  url: string;
+  port: number;
+  host: string;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Resolve the local Vite entry script via createRequire so we
+ * launch the workspace's exact version, not whatever's on PATH.
+ */
+function resolveViteBin(cwd: string): string {
+  const require = createRequire(path.join(cwd, 'package.json'));
+  // Vite ships its CLI entry as bin/vite.js. The package.json `bin`
+  // field maps "vite" → "bin/vite.js"; resolving the package then
+  // joining is more robust than relying on `require.resolve('vite/bin/vite.js')`
+  // which fails when the host project has a different export map.
+  const vitePkg = require.resolve('vite/package.json');
+  return path.join(path.dirname(vitePkg), 'bin', 'vite.js');
+}
+
+export async function startViteServer(
+  cwd: string,
+  host: string,
+  port: number,
+): Promise<ViteServer> {
+  const viteBin = resolveViteBin(cwd);
+  const args = [viteBin, '--host', host, '--port', String(port), '--strictPort'];
+
+  const child = spawn(process.execPath, args, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, FORCE_COLOR: '0' },
+    windowsHide: true,
+  });
+
+  if (child.pid !== undefined) {
+    const unregister = registerPid(child.pid);
+    child.once('exit', unregister);
+  }
+
+  const url = await waitForViteReady(child, host, port);
+  return {
+    url,
+    port,
+    host,
+    stop: () => stopProcess(child),
+  };
+}
+
+function waitForViteReady(child: ChildProcess, host: string, port: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const READY_TIMEOUT_MS = 120_000;
+    const startedAt = Date.now();
+    let resolved = false;
+    let buffered = '';
+
+    const timer = setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      reject(new Error(`Vite did not become ready within ${READY_TIMEOUT_MS} ms\n--- output ---\n${buffered.slice(-2000)}`));
+    }, READY_TIMEOUT_MS);
+
+    const onData = (chunk: Buffer | string) => {
+      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      buffered += text;
+      if (resolved) return;
+      // Vite prints "Local:   http://localhost:5173/" once ready, but
+      // the line is colored — strip ANSI escape codes before matching.
+      // Use the standard ANSI CSI / OSC sequence pattern.
+      // eslint-disable-next-line no-control-regex
+      const clean = buffered.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
+      if (/Local:\s+http/i.test(clean)) {
+        resolved = true;
+        clearTimeout(timer);
+        resolve(`http://${host}:${port}`);
+      }
+    };
+
+    child.stdout?.on('data', onData);
+    child.stderr?.on('data', onData);
+    child.once('exit', (code) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
+      reject(
+        new Error(
+          `Vite exited with code ${code} before becoming ready after ${Date.now() - startedAt} ms\n--- output ---\n${buffered.slice(-2000)}`,
+        ),
+      );
+    });
+  });
+}
+
+function stopProcess(child: ChildProcess): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+      return;
+    }
+    child.once('exit', () => resolve());
+    // On Windows, kill the whole tree via taskkill — sending SIGTERM
+    // to a Node child sometimes leaves Vite's esbuild service alive.
+    if (process.platform === 'win32' && child.pid !== undefined) {
+      spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      }).on('exit', () => resolve());
+    } else {
+      child.kill('SIGTERM');
+      // Backstop: SIGKILL after a second if it hasn't exited.
+      setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGKILL');
+        }
+      }, 1000);
+    }
+  });
+}

--- a/scripts/lib/export/ffmpegCompose.ts
+++ b/scripts/lib/export/ffmpegCompose.ts
@@ -1,0 +1,88 @@
+/**
+ * Compose a frame sequence + (optional) narration audio into an MP4
+ * via ffmpeg-static. No audio mixing in Phase 3 — the SPA plays TTS
+ * live during capture but the audio is NOT recorded by CDP screencast;
+ * we emit a silent MP4 for now. A follow-up can add pre-rendered
+ * TTS clips composed at segmentTimings offsets (Clio's pattern).
+ *
+ * Silent-MP4-first keeps Phase 3 reviewable. Audio mux lands as a
+ * Phase 3.1 follow-up after Phase 3 merges.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { registerPid } from './processRegistry';
+
+export interface ComposeOptions {
+  /** Absolute path to a directory containing frame_00000000.jpg, frame_00000001.jpg, … */
+  frameDir: string;
+  /** Frame rate matching the writer's output (typically 30). */
+  frameRate: number;
+  /** Absolute output path for the .mp4 file. */
+  outputPath: string;
+  /** Absolute path to the ffmpeg binary. */
+  ffmpegPath: string;
+}
+
+/**
+ * Run ffmpeg to encode the frame sequence into a playable MP4.
+ *
+ * Args breakdown:
+ *   -framerate <rate>         expected input frame rate
+ *   -i frame_%08d.jpg         glob of JPEG inputs
+ *   -c:v libx264              widely-supported H.264 encoder
+ *   -pix_fmt yuv420p          required for QuickTime / browser playback
+ *   -movflags +faststart      enables streaming (metadata at file head)
+ *   -preset veryfast          balance speed vs. file size; iteration friendly
+ *   -crf 20                   visually transparent quality (good for code text)
+ *   -y                        overwrite output without prompting
+ */
+export async function composeMp4(options: ComposeOptions): Promise<void> {
+  await mkdir(path.dirname(options.outputPath), { recursive: true });
+  const args = [
+    '-y',
+    '-framerate',
+    String(options.frameRate),
+    '-i',
+    path.join(options.frameDir, 'frame_%08d.jpg'),
+    '-c:v',
+    'libx264',
+    '-pix_fmt',
+    'yuv420p',
+    '-movflags',
+    '+faststart',
+    '-preset',
+    'veryfast',
+    '-crf',
+    '20',
+    options.outputPath,
+  ];
+  console.log(`[ffmpeg] composing ${options.outputPath}`);
+  await runFfmpeg(options.ffmpegPath, args);
+}
+
+function runFfmpeg(ffmpegPath: string, args: string[]): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child: ChildProcess = spawn(ffmpegPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    if (child.pid !== undefined) {
+      const unregister = registerPid(child.pid);
+      child.once('exit', unregister);
+    }
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`ffmpeg exited with code ${code}\n--- stderr tail ---\n${stderr.slice(-2000)}`));
+      }
+    });
+  });
+}

--- a/scripts/lib/export/frameSequenceWriter.ts
+++ b/scripts/lib/export/frameSequenceWriter.ts
@@ -1,0 +1,96 @@
+/**
+ * Buffers JPEG screencast frames to disk at a fixed frame rate.
+ *
+ * CDP Page.startScreencast emits frames as base64 JPEGs at whatever
+ * rate Chromium decides (typically 30 fps when motion is heavy,
+ * dropping when the page is idle). For ffmpeg we need a regular
+ * frame sequence — frame_NNNNNNNN.jpg where N is the playback time
+ * divided by the frame interval.
+ *
+ * Approach: ingest frames keyed by their arrival timestamp (ms from
+ * record start), then on finalize, replay the buffer to emit one
+ * frame per fixed interval, repeating the most-recent frame when
+ * Chromium dropped one. ffmpeg consumes the resulting sequence with
+ * `-framerate <rate>` and the math just works.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export interface FrameSequenceWriterOptions {
+  /** Absolute directory where frames are written. Must already exist. */
+  frameDir: string;
+  /** Target frame rate; the output sequence has one file per 1/N seconds. */
+  frameRate: number;
+}
+
+interface BufferedFrame {
+  data: Buffer;
+  receivedMs: number;
+}
+
+export class FrameSequenceWriter {
+  private readonly frameDir: string;
+  private readonly frameRate: number;
+  private readonly intervalMs: number;
+  private startedAtMs = 0;
+  private buffer: BufferedFrame[] = [];
+
+  constructor(options: FrameSequenceWriterOptions) {
+    this.frameDir = options.frameDir;
+    this.frameRate = options.frameRate;
+    this.intervalMs = 1000 / options.frameRate;
+  }
+
+  /** Begin accepting frames. receivedMs is measured from this point. */
+  start(startedAtMs: number): void {
+    this.startedAtMs = startedAtMs;
+    this.buffer = [];
+  }
+
+  /**
+   * Ingest a screencast frame. base64Data is the raw CDP payload;
+   * receivedAtMs is Date.now() at receipt time.
+   */
+  ingest(base64Data: string, receivedAtMs: number): void {
+    if (this.startedAtMs === 0) return;
+    this.buffer.push({
+      data: Buffer.from(base64Data, 'base64'),
+      receivedMs: receivedAtMs - this.startedAtMs,
+    });
+  }
+
+  /**
+   * Stop accepting frames, emit the fixed-rate sequence to disk.
+   * Returns the number of frames written.
+   *
+   * Emission rule: for each output slot at time T = i * intervalMs,
+   * pick the most-recent buffered frame whose receivedMs <= T. When
+   * Chromium dropped frames (T < first receivedMs), use the first
+   * frame as a placeholder.
+   */
+  async finalize(captureDurationMs: number): Promise<number> {
+    if (this.buffer.length === 0) {
+      throw new Error('FrameSequenceWriter: no frames were ingested');
+    }
+    // Sort defensively — events should arrive in order, but a stray
+    // race in CDP delivery isn't impossible.
+    const sorted = [...this.buffer].sort((a, b) => a.receivedMs - b.receivedMs);
+
+    const frameCount = Math.max(1, Math.round((captureDurationMs / 1000) * this.frameRate));
+    let cursor = 0; // index into `sorted` of the current "active" frame
+    const writes: Promise<void>[] = [];
+    for (let i = 0; i < frameCount; i++) {
+      const slotMs = i * this.intervalMs;
+      // Advance the cursor to the latest frame whose timestamp <= slotMs.
+      while (cursor + 1 < sorted.length && sorted[cursor + 1].receivedMs <= slotMs) {
+        cursor++;
+      }
+      const frame = sorted[cursor];
+      const file = path.join(this.frameDir, `frame_${String(i).padStart(8, '0')}.jpg`);
+      writes.push(writeFile(file, frame.data));
+    }
+    await Promise.all(writes);
+    return frameCount;
+  }
+}

--- a/scripts/lib/export/processRegistry.ts
+++ b/scripts/lib/export/processRegistry.ts
@@ -1,0 +1,72 @@
+/**
+ * Tracks PIDs of long-running children (Vite, Chromium, ffmpeg) so
+ * the export script's signal handlers can tree-kill them on Ctrl+C.
+ *
+ * On Windows, killing a Node child with SIGTERM doesn't propagate to
+ * grandchildren (esbuild, chromium renderers, etc.) — they orphan.
+ * The signal handlers walk the registry and call `taskkill /t /f`.
+ *
+ * Mirrors Clio's scripts/lib/export/processRegistry.ts narrowly:
+ * just the PID set, the register/unregister API, and the signal
+ * handlers. No watchdog, no idle-timeout, no per-process metadata.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+const tracked = new Set<number>();
+let handlersInstalled = false;
+
+/**
+ * Register a PID. Returns an unregister function to call when the
+ * process exits normally. Idempotent.
+ */
+export function registerPid(pid: number): () => void {
+  tracked.add(pid);
+  installHandlersOnce();
+  return () => {
+    tracked.delete(pid);
+  };
+}
+
+/** Kill all tracked PIDs immediately (best-effort tree-kill). */
+export function killAllTracked(): void {
+  for (const pid of tracked) {
+    try {
+      if (process.platform === 'win32') {
+        spawnSync('taskkill', ['/pid', String(pid), '/t', '/f'], {
+          stdio: 'ignore',
+          windowsHide: true,
+        });
+      } else {
+        process.kill(pid, 'SIGTERM');
+      }
+    } catch {
+      // Process may already be dead; ignore.
+    }
+  }
+  tracked.clear();
+}
+
+function installHandlersOnce(): void {
+  if (handlersInstalled) return;
+  handlersInstalled = true;
+  // SIGINT (Ctrl+C) and SIGTERM (graceful kill from a parent) both
+  // route through the same cleanup. The handler is synchronous —
+  // async cleanup is unreliable from signal handlers, and taskkill
+  // /f is effectively synchronous anyway.
+  const handle = (signal: NodeJS.Signals): void => {
+    killAllTracked();
+    // Re-raise so the default behaviour (exit) still happens.
+    process.kill(process.pid, signal);
+  };
+  process.once('SIGINT', () => handle('SIGINT'));
+  process.once('SIGTERM', () => handle('SIGTERM'));
+  // uncaughtException keeps the cleanup running on a programming
+  // error — without it, Vite/Chromium orphan when the script throws.
+  process.once('uncaughtException', (err) => {
+    console.error('[export] uncaught exception, cleaning up children');
+    console.error(err);
+    killAllTracked();
+    process.exit(1);
+  });
+}

--- a/src/app/broadcastConfig.ts
+++ b/src/app/broadcastConfig.ts
@@ -1,0 +1,84 @@
+/**
+ * URL-driven broadcast mode for the MP4 export pipeline.
+ *
+ * The capture pipeline (Phase 3) opens the SPA with a fixed set of query
+ * params and expects a deterministic, chrome-free layout that auto-plays
+ * a known PGN. This module parses those params once at module load.
+ *
+ * The config is intentionally read-only and computed once. Re-running
+ * the capture means reloading the page — there is no in-app way to
+ * toggle broadcast mode.
+ */
+
+export interface BroadcastConfig {
+  /** True when ?export=1 is set. Strips chrome and skips the normal tab UI. */
+  exportMode: boolean;
+  /** True when ?broadcast=1 is set. Disables interactive affordances. */
+  broadcast: boolean;
+  /** Episode id from ?episode=<id>. Resolves through CHESS_EPISODES. */
+  episodeId: string | null;
+  /** Raw PGN text from ?pgn=<encoded>. Bypasses the registry. */
+  rawPgn: string | null;
+  /**
+   * Optional clip id from ?shortId=<id>. Phase 4 selects a highlight
+   * range; ignored entirely in Phase 1.
+   */
+  shortId: string | null;
+  /** Optional viewport width from ?w=<px>. Defaults to 1920. */
+  viewportWidth: number | null;
+  /** Optional viewport height from ?h=<px>. Defaults to 1080. */
+  viewportHeight: number | null;
+}
+
+function parseFlag(params: URLSearchParams, key: string): boolean {
+  const raw = params.get(key);
+  if (raw === null) return false;
+  return raw === '1' || raw === 'true';
+}
+
+function parsePositiveInt(params: URLSearchParams, key: string): number | null {
+  const raw = params.get(key);
+  if (!raw) return null;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function parse(): BroadcastConfig {
+  if (typeof window === 'undefined') {
+    return {
+      exportMode: false,
+      broadcast: false,
+      episodeId: null,
+      rawPgn: null,
+      shortId: null,
+      viewportWidth: null,
+      viewportHeight: null,
+    };
+  }
+  const params = new URLSearchParams(window.location.search);
+  return {
+    exportMode: parseFlag(params, 'export'),
+    broadcast: parseFlag(params, 'broadcast'),
+    episodeId: params.get('episode'),
+    rawPgn: params.get('pgn'),
+    shortId: params.get('shortId'),
+    viewportWidth: parsePositiveInt(params, 'w'),
+    viewportHeight: parsePositiveInt(params, 'h'),
+  };
+}
+
+let cached: BroadcastConfig | null = null;
+
+/**
+ * Returns the parsed broadcast config. Parses once on first call;
+ * subsequent calls return the cached value.
+ */
+export function getBroadcastConfig(): BroadcastConfig {
+  if (!cached) cached = parse();
+  return cached;
+}
+
+/** True if the current page load is a broadcast/export run. */
+export function isBroadcastMode(): boolean {
+  return getBroadcastConfig().exportMode;
+}

--- a/src/app/exportBridge.ts
+++ b/src/app/exportBridge.ts
@@ -1,0 +1,133 @@
+/**
+ * window.__CHESS_EXPORT__ bridge — the handshake contract between the
+ * SPA and the headless-Chromium capture pipeline (Phase 3).
+ *
+ * The capture pipeline does, in order:
+ *
+ *   1. Open the SPA with ?export=1&broadcast=1&episode=<id>
+ *   2. Wait for state().ready && painted && replayReady && audioReady
+ *   3. Call reset() and start()
+ *   4. Stream JPEG frames via CDP Page.startScreencast
+ *   5. Wait for state().ended
+ *   6. Read state().segmentTimings for audio/caption alignment
+ *
+ * Mirrors Clio's __CLIO_EXPORT__ contract so the lifted capture
+ * scaffolding (Phase 3) ports with minimal modification.
+ */
+
+export interface ExportBridgeState {
+  /** SPA has mounted and parsed broadcast config. */
+  ready: boolean;
+  /** Page has committed at least one React render plus one rAF tick. */
+  painted: boolean;
+  /** Broadcast layout is active (mirrors broadcastConfig.exportMode). */
+  broadcastMode: boolean;
+  /** PGN parsed, ChessBoard initialized, replay runtime ready to start. */
+  replayReady: boolean;
+  /** AudioContext is unlocked (or TTS is disabled). */
+  audioReady: boolean;
+  /** GameEnded / GameAborted has fired. */
+  ended: boolean;
+  /**
+   * Map of timeline-segment-index to milliseconds-since-start(),
+   * populated by AudioNarrationQueue in Phase 2. Empty in Phase 1.
+   */
+  segmentTimings: Record<number, number>;
+}
+
+/**
+ * Hooks supplied by BroadcastView so the bridge can drive the replay.
+ * The bridge owns the state machine; the React view owns the runtime
+ * lifecycle.
+ */
+export interface ExportBridgeHooks {
+  start: () => void;
+  reset: () => void;
+}
+
+export interface ExportBridge {
+  reset(): void;
+  start(): void;
+  state(): ExportBridgeState;
+  /** Internal: BroadcastView calls this after mount. */
+  __register(hooks: ExportBridgeHooks): void;
+  /** Internal: rAF callback after first paint. */
+  __markPainted(): void;
+  /** Internal: PGN loaded + ReplayRuntime ready. */
+  __markReplayReady(ready: boolean): void;
+  /** Internal: AudioContext unlocked (or TTS off). */
+  __markAudioReady(ready: boolean): void;
+  /** Internal: GameEnded / GameAborted fired. */
+  __markEnded(): void;
+  /** Internal: AudioNarrationQueue records per-segment paint offset. */
+  __recordSegmentTiming(segmentIndex: number, offsetMs: number): void;
+  /** Internal: installExportBridge sets broadcastMode at boot. */
+  __setBroadcastMode(value: boolean): void;
+}
+
+const state: ExportBridgeState = {
+  ready: false,
+  painted: false,
+  broadcastMode: false,
+  replayReady: false,
+  audioReady: false,
+  ended: false,
+  segmentTimings: {},
+};
+
+let hooks: ExportBridgeHooks | null = null;
+
+export const exportBridge: ExportBridge = {
+  reset() {
+    state.painted = false;
+    state.replayReady = false;
+    state.audioReady = false;
+    state.ended = false;
+    state.segmentTimings = {};
+    hooks?.reset();
+  },
+  start() {
+    if (!hooks) {
+      console.warn('[__CHESS_EXPORT__] start() called before BroadcastView mounted');
+      return;
+    }
+    hooks.start();
+  },
+  state() {
+    // Return a shallow copy so callers can't mutate internal state.
+    // segmentTimings is also cloned because it grows during playback.
+    return { ...state, segmentTimings: { ...state.segmentTimings } };
+  },
+  __register(newHooks) {
+    hooks = newHooks;
+    state.ready = true;
+  },
+  __markPainted() {
+    state.painted = true;
+  },
+  __markReplayReady(ready) {
+    state.replayReady = ready;
+  },
+  __markAudioReady(ready) {
+    state.audioReady = ready;
+  },
+  __markEnded() {
+    state.ended = true;
+  },
+  __recordSegmentTiming(segmentIndex, offsetMs) {
+    state.segmentTimings[segmentIndex] = offsetMs;
+  },
+  __setBroadcastMode(value) {
+    state.broadcastMode = value;
+  },
+};
+
+/**
+ * Install the bridge on the window object. Called once from main.tsx
+ * during boot. Skipped in non-browser contexts (SSR, test runner).
+ */
+export function installExportBridge(broadcastMode: boolean): void {
+  if (typeof window === 'undefined') return;
+  exportBridge.__setBroadcastMode(broadcastMode);
+  (window as unknown as { __CHESS_EXPORT__: ExportBridge }).__CHESS_EXPORT__ = exportBridge;
+}

--- a/src/app/exportBridge.ts
+++ b/src/app/exportBridge.ts
@@ -29,10 +29,24 @@ export interface ExportBridgeState {
   /** GameEnded / GameAborted has fired. */
   ended: boolean;
   /**
-   * Map of timeline-segment-index to milliseconds-since-start(),
-   * populated by AudioNarrationQueue in Phase 2. Empty in Phase 1.
+   * Map of {moveIndex → offsetMs from start()}. Populated by
+   * AudioNarrationQueue when each commentary entry's first sentence
+   * begins playing. Phase 3 uses this to retime the render plan so
+   * composed audio sits at the exact paint moment.
+   *
+   * Keyed by 0-indexed ply (matching AudioNarrationQueue's
+   * maxMoveIndex). The Phase 3 export pipeline calls
+   * retimeRenderPlanWithSegmentTimings(plan, segmentTimings) to map
+   * these back onto plan timeline indices.
    */
   segmentTimings: Record<number, number>;
+  /**
+   * Render plan attached by BroadcastView when start() is called.
+   * Useful for diagnostics; the capture pipeline already has the plan
+   * it built before opening the page, so this field is informational.
+   * Optional to keep the contract backward-compatible with Phase 1.
+   */
+  renderPlan?: unknown;
 }
 
 /**
@@ -59,8 +73,13 @@ export interface ExportBridge {
   __markAudioReady(ready: boolean): void;
   /** Internal: GameEnded / GameAborted fired. */
   __markEnded(): void;
-  /** Internal: AudioNarrationQueue records per-segment paint offset. */
-  __recordSegmentTiming(segmentIndex: number, offsetMs: number): void;
+  /**
+   * Internal: AudioNarrationQueue records per-move paint offset (the
+   * moment commentary for that move began playing).
+   */
+  __recordSegmentTiming(moveIndex: number, offsetMs: number): void;
+  /** Internal: BroadcastView attaches the render plan when start() runs. */
+  __setRenderPlan(plan: unknown): void;
   /** Internal: installExportBridge sets broadcastMode at boot. */
   __setBroadcastMode(value: boolean): void;
 }
@@ -114,8 +133,11 @@ export const exportBridge: ExportBridge = {
   __markEnded() {
     state.ended = true;
   },
-  __recordSegmentTiming(segmentIndex, offsetMs) {
-    state.segmentTimings[segmentIndex] = offsetMs;
+  __recordSegmentTiming(moveIndex, offsetMs) {
+    state.segmentTimings[moveIndex] = offsetMs;
+  },
+  __setRenderPlan(plan) {
+    state.renderPlan = plan;
   },
   __setBroadcastMode(value) {
     state.broadcastMode = value;

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -5,6 +5,8 @@ import { getBroadcastConfig } from '../app/broadcastConfig';
 import { exportBridge } from '../app/exportBridge';
 import { getEpisode, DEFAULT_EPISODE_ID } from '../episodes';
 import { TournamentProgress } from './TournamentProgress';
+import { getActiveAudioNarrationQueue } from '../tts/audio-queue';
+import { createRenderPlanFromPgn, type RenderPlan } from '../production/renderPlan';
 
 /**
  * BroadcastView — the chrome-free, auto-playing layout used by the
@@ -64,6 +66,10 @@ export function BroadcastView() {
   }, [episodeCommentatorModel, setReplayCommentatorModel]);
 
   // Register bridge hooks so the capture pipeline can drive start/reset.
+  // On start(), build a render plan from the PGN, attach it to the
+  // bridge for diagnostics, mark the active audio queue's playback
+  // start time, and wire the segment-start callback so each commentary
+  // entry's first sentence records a paint offset.
   useEffect(() => {
     exportBridge.__register({
       start: () => {
@@ -76,6 +82,29 @@ export function BroadcastView() {
           return;
         }
         startedRef.current = true;
+
+        const config = getBroadcastConfig();
+        const plan: RenderPlan = createRenderPlanFromPgn({
+          id: config.episodeId ?? 'inline-pgn',
+          runId: `run:${Date.now()}`,
+          title: 'Broadcast capture',
+          pgn: pgnText,
+          episodeId: config.episodeId ?? undefined,
+        });
+        exportBridge.__setRenderPlan(plan);
+
+        const audioQueue = getActiveAudioNarrationQueue();
+        if (audioQueue) {
+          audioQueue.markPlaybackStart(performance.now());
+          audioQueue.setSegmentStartCallback((moveIndex, offsetMs) => {
+            exportBridge.__recordSegmentTiming(moveIndex, offsetMs);
+          });
+        } else {
+          console.warn(
+            '[BroadcastView] No active AudioNarrationQueue at start() — segment timings will not be recorded',
+          );
+        }
+
         startReplay(pgnText, {
           historicalContext,
           moveDelayMs: 0,
@@ -84,6 +113,14 @@ export function BroadcastView() {
       },
       reset: () => {
         startedRef.current = false;
+        const audioQueue = getActiveAudioNarrationQueue();
+        if (audioQueue) {
+          // Disable segment-timing emission; markPlaybackStart(0)
+          // sets the gate field to 0 which the queue treats as "not
+          // in broadcast mode."
+          audioQueue.markPlaybackStart(0);
+          audioQueue.setSegmentStartCallback(null);
+        }
         if (replayMode) stopReplay();
       },
     });

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTournamentStore } from '../store/tournamentStore';
+import { useSettingsStore } from '../store/settingsStore';
+import { getBroadcastConfig } from '../app/broadcastConfig';
+import { exportBridge } from '../app/exportBridge';
+import { getEpisode, DEFAULT_EPISODE_ID } from '../episodes';
+import { TournamentProgress } from './TournamentProgress';
+
+/**
+ * BroadcastView — the chrome-free, auto-playing layout used by the
+ * MP4 export pipeline.
+ *
+ * Mounted by App.tsx when ?export=1 is present. Resolves the PGN
+ * source (episode id or inline pgn), registers __CHESS_EXPORT__
+ * hooks, and renders TournamentProgress — which already owns the
+ * full commentary queue, TTS, narration gate, and game layout
+ * wiring. Reusing it avoids duplicating ~1000 lines of orchestration.
+ *
+ * The bridge taps the lifecycle by watching the tournament store
+ * (activeGameState.status) rather than reaching into
+ * TournamentProgress internals.
+ */
+export function BroadcastView() {
+  const config = getBroadcastConfig();
+  const startReplay = useTournamentStore(s => s.startReplay);
+  const stopReplay = useTournamentStore(s => s.stopReplay);
+  const activeGameState = useTournamentStore(s => s.activeGameState);
+  const replayMode = useTournamentStore(s => s.replayMode);
+  const setReplayCommentatorModel = useTournamentStore(s => s.setReplayCommentatorModel);
+  const ttsEnabled = useSettingsStore(s => s.ttsEnabled);
+
+  // PGN source resolution. Broadcast config comes from URL params and
+  // never changes during a page lifetime, so we resolve once with a
+  // lazy useState initializer — no effect, no cascading renders.
+  const [pgnText] = useState<string | null>(() => resolvePgnSource(config).pgnText);
+  const [loadError] = useState<string | null>(() => resolvePgnSource(config).error);
+  const [historicalContext] = useState<string | undefined>(() => resolvePgnSource(config).historicalContext);
+  const [episodeCommentatorModel] = useState<string | null>(() => resolvePgnSource(config).commentatorModel);
+
+  const startedRef = useRef(false);
+  const commentatorAppliedRef = useRef(false);
+
+  // Apply the episode's commentator model id to the replay store
+  // once. Reads existing config via getState() inside the effect so we
+  // don't re-stomp the user's reasoning/verbosity settings on every
+  // store change.
+  useEffect(() => {
+    if (commentatorAppliedRef.current || !episodeCommentatorModel) return;
+    commentatorAppliedRef.current = true;
+    const existing = useTournamentStore.getState().replayCommentatorModel;
+    setReplayCommentatorModel({
+      ...(existing ?? {
+        id: '',
+        name: '',
+        mode: 'llm' as const,
+        reasoningEffort: 'high' as const,
+        maxTokens: 16000,
+        stockfishDepth: 18,
+      }),
+      id: episodeCommentatorModel,
+      name: episodeCommentatorModel,
+      mode: 'llm',
+    });
+  }, [episodeCommentatorModel, setReplayCommentatorModel]);
+
+  // Register bridge hooks so the capture pipeline can drive start/reset.
+  useEffect(() => {
+    exportBridge.__register({
+      start: () => {
+        if (startedRef.current) {
+          console.warn('[BroadcastView] start() called twice; ignoring');
+          return;
+        }
+        if (!pgnText) {
+          console.warn('[BroadcastView] start() before PGN is loaded');
+          return;
+        }
+        startedRef.current = true;
+        startReplay(pgnText, {
+          historicalContext,
+          moveDelayMs: 0,
+          startFromPly: 0,
+        });
+      },
+      reset: () => {
+        startedRef.current = false;
+        if (replayMode) stopReplay();
+      },
+    });
+  }, [pgnText, historicalContext, startReplay, stopReplay, replayMode]);
+
+  useEffect(() => {
+    exportBridge.__markReplayReady(Boolean(pgnText) && !loadError);
+  }, [pgnText, loadError]);
+
+  // Audio readiness: when TTS is disabled the page is trivially
+  // audio-ready. When TTS is enabled the AudioContext is created
+  // lazily by AudioNarrationQueue on first synth; under Chromium with
+  // --autoplay-policy=no-user-gesture-required (the Phase 3 launch
+  // flag) this happens immediately without a user gesture, so we
+  // optimistically signal ready as soon as the bridge is installed.
+  useEffect(() => {
+    exportBridge.__markAudioReady(true);
+  }, [ttsEnabled]);
+
+  // Paint flag: rAF after first React commit guarantees layout is on
+  // screen. Mirrors Clio's painted+mapIdle gate.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => exportBridge.__markPainted());
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  // End flag: replay reaches a terminal status. GameStatus is a
+  // discriminated union — every value except 'created' and
+  // 'in_progress' is terminal.
+  useEffect(() => {
+    if (!activeGameState) return;
+    const status = activeGameState.status;
+    if (status !== 'created' && status !== 'in_progress') {
+      exportBridge.__markEnded();
+    }
+  }, [activeGameState]);
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen bg-surface-0 flex items-center justify-center">
+        <div className="max-w-2xl text-center p-6">
+          <div className="text-red-400 text-lg font-semibold mb-2">Broadcast load error</div>
+          <div className="text-text-secondary text-sm whitespace-pre-wrap">{loadError}</div>
+          <div className="text-text-muted text-xs mt-4">
+            URL params: episode={config.episodeId ?? '(none)'} pgn={config.rawPgn ? 'inline' : '(none)'}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!pgnText) {
+    return (
+      <div className="min-h-screen bg-surface-0 flex items-center justify-center">
+        <div className="text-text-muted text-sm">Loading PGN…</div>
+      </div>
+    );
+  }
+
+  // Once the replay has started, hand off to TournamentProgress which
+  // already owns the full commentary/TTS/board pipeline. Before
+  // start(), show a wait card so the screencast doesn't capture the
+  // landing chrome.
+  if (!replayMode) {
+    return (
+      <div className="min-h-screen bg-surface-0 flex items-center justify-center">
+        <div className="text-text-muted text-sm">Waiting for __CHESS_EXPORT__.start()…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-surface-0 p-3">
+      <TournamentProgress />
+    </div>
+  );
+}
+
+interface ResolvedPgnSource {
+  pgnText: string | null;
+  error: string | null;
+  historicalContext: string | undefined;
+  commentatorModel: string | null;
+}
+
+/**
+ * Resolve a BroadcastConfig to a PGN source, historical context, and
+ * episode commentator model. Pure / synchronous so it can run inside
+ * a useState initializer.
+ */
+function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): ResolvedPgnSource {
+  if (config.rawPgn) {
+    return {
+      pgnText: config.rawPgn,
+      error: null,
+      historicalContext: undefined,
+      commentatorModel: null,
+    };
+  }
+  const episodeId = config.episodeId ?? DEFAULT_EPISODE_ID;
+  if (!episodeId) {
+    return {
+      pgnText: null,
+      error: 'No episode id supplied and no default episode is registered.',
+      historicalContext: undefined,
+      commentatorModel: null,
+    };
+  }
+  const episode = getEpisode(episodeId);
+  if (!episode) {
+    return {
+      pgnText: null,
+      error: `Unknown episode id "${episodeId}". Check src/episodes/registry.ts.`,
+      historicalContext: undefined,
+      commentatorModel: null,
+    };
+  }
+  return {
+    pgnText: episode.pgn,
+    error: null,
+    historicalContext: episode.historicalContext,
+    commentatorModel: episode.commentator.model,
+  };
+}

--- a/src/components/CommentaryPanel.tsx
+++ b/src/components/CommentaryPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CommentaryEntry } from '../commentary/commentaryQueue';
-import { AudioNarrationQueue, type NarrationMove } from '../tts/audio-queue';
+import { AudioNarrationQueue, registerAudioNarrationQueue, type NarrationMove } from '../tts/audio-queue';
 import { checkTtsHealth, checkCloudTtsHealth, type TtsStatus, type TtsSynthesizeOptions } from '../tts/tts-client';
 import { useSettingsStore } from '../store/settingsStore';
 import { segmentChessMoves } from '../utils/chess-squares';
@@ -76,11 +76,17 @@ export function CommentaryPanel({ entries, commentatorModelName, sessionKey, onN
     registerNarrationGate(() => audioQueueRef.current?.waitUntilDone() ?? Promise.resolve());
     // Register stop callback so aborting/skipping kills audio immediately
     registerNarrationStop(() => audioQueueRef.current?.stop());
+    // Expose this queue to the MP4-export broadcast path so it can
+    // call markPlaybackStart() and setSegmentStartCallback() on the
+    // active instance without reaching into React internals. No-op
+    // outside broadcast mode.
+    registerAudioNarrationQueue(audioQueueRef.current);
     return () => {
       // Stop any playing audio when component unmounts or effect re-runs
       audioQueueRef.current?.stop();
       registerNarrationGate(null);
       registerNarrationStop(null);
+      registerAudioNarrationQueue(null);
     };
   }, [ttsVolume]);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,22 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import { App } from './App'
+import { BroadcastView } from './components/BroadcastView'
+import { getBroadcastConfig } from './app/broadcastConfig'
+import { installExportBridge } from './app/exportBridge'
+
+const broadcastConfig = getBroadcastConfig();
+installExportBridge(broadcastConfig.exportMode);
+
+// Broadcast / MP4-export mode bypasses the normal App tree entirely.
+// The capture pipeline only needs the BroadcastView + tournament store
+// + commentary queue — none of the tabs, ApiKey input, TechDiff
+// overlay, or fullscreen handling apply. Routing here (vs. inside
+// App.tsx) keeps App's hook order stable for the normal SPA case.
+const Root = broadcastConfig.exportMode ? BroadcastView : App;
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Root />
   </StrictMode>,
 )

--- a/src/production/renderPlan.ts
+++ b/src/production/renderPlan.ts
@@ -1,0 +1,364 @@
+/**
+ * Render plan — the deterministic timeline a capture pipeline replays.
+ *
+ * A render plan describes every move and commentary segment of a game
+ * with a planned start offset and duration. The capture pipeline opens
+ * the SPA in broadcast mode, calls __CHESS_EXPORT__.start(), reads the
+ * actual paint offsets back out as `segmentTimings`, then calls
+ * `retimeRenderPlanWithSegmentTimings` to produce a plan whose
+ * durations match what actually played.
+ *
+ * Shape mirrors Clio's RenderPlan / RenderTarget / TimelineItem
+ * vocabulary so the lifted capture scaffolding (Phase 3) ports
+ * cleanly.
+ */
+
+import { parseSinglePgn, type PgnGame, type PgnMove } from '../pgn/parser';
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type TimelineItemKind = 'move' | 'commentary' | 'gap';
+
+export interface TimelineItem {
+  /** Monotonically increasing across the target's timeline. */
+  index: number;
+  kind: TimelineItemKind;
+  /** Planned start offset within the target, in ms. */
+  startMs: number;
+  /** Planned duration, in ms. Re-measured by the capture pipeline. */
+  durationMs: number;
+  /**
+   * Move index this item belongs to (0-indexed ply). Present on
+   * 'move' and 'commentary' kinds; absent on 'gap'.
+   */
+  moveIndex?: number;
+  /** SAN move text. Present on 'move' and 'commentary' kinds. */
+  sanMove?: string;
+  /** Color whose move this is. Present on 'move' and 'commentary' kinds. */
+  color?: 'w' | 'b';
+  /** FEN after the move. Present on 'move' kind. */
+  fen?: string;
+  /**
+   * Planned commentary text. Present on 'commentary' kind in the
+   * initial plan; replaced with the actual generated text after
+   * playback by the export pipeline. May be empty when the plan is
+   * built before commentary generation runs.
+   */
+  text?: string;
+}
+
+export interface Viewport {
+  width: number;
+  height: number;
+  /** Informational, e.g. '16:9' or '9:16'. */
+  aspectRatio?: string;
+  deviceScaleFactor?: number;
+}
+
+export interface RenderArtifact {
+  fileName: string;
+  durationMs: number;
+}
+
+export type RenderTargetKind = 'full' | 'short';
+
+export interface RenderTarget {
+  id: string;
+  kind: RenderTargetKind;
+  viewport: Viewport;
+  range: {
+    startMs: number;
+    endMs: number;
+    /** Index of the last timeline item included. */
+    endSegmentIndex: number;
+  };
+  timeline: TimelineItem[];
+  artifact: RenderArtifact;
+  outputPath: string;
+  /** Phase 4 only — clip id this short was sliced from. Absent on 'full'. */
+  shortId?: string;
+}
+
+export interface NarrationTiming {
+  /** Per-character TTS speech rate, in ms. ~50 ms ≈ 200 wpm. */
+  textMsPerChar: number;
+  /** Floor duration for a commentary block. */
+  textMinMs: number;
+  /** Ceiling so an outlier doesn't dominate the timeline. */
+  textMaxMs: number;
+  /** Duration of a 'move' segment (board update, brief pause). */
+  moveDurationMs: number;
+  /** Duration of a 'gap' segment between move and commentary. */
+  gapDurationMs: number;
+}
+
+/**
+ * Default narration timing tuned for game-review pacing. Commentary
+ * blocks land in the 4–18 s range; moves get ~1.5 s of board focus
+ * before the narrator starts talking.
+ *
+ * These are PLANNED durations only — the capture pipeline replaces
+ * them with measured durations via retimeRenderPlanWithSegmentTimings.
+ */
+export const NATURAL_NARRATION_TIMING: NarrationTiming = {
+  textMsPerChar: 55,
+  textMinMs: 4_000,
+  textMaxMs: 18_000,
+  moveDurationMs: 1_500,
+  gapDurationMs: 600,
+};
+
+export interface RenderPlan {
+  id: string;
+  runId: string;
+  /** Game-review-specific provenance: episode id when one was selected. */
+  episodeId?: string;
+  title: string;
+  createdAt: string;
+  timing: NarrationTiming;
+  fullEpisode: RenderTarget;
+  /** Phase 4 will populate this from detected highlight clips. */
+  shorts: RenderTarget[];
+  /** Original parsed game for downstream consumers (e.g. retime). */
+  pgnHeaders: Record<string, string | undefined>;
+  /** Optional output root used by CLI scripts. */
+  outputRoot?: string;
+}
+
+// ─── Plan construction ──────────────────────────────────────────────
+
+export interface CreateRenderPlanOptions {
+  id: string;
+  runId: string;
+  title: string;
+  pgn: string;
+  episodeId?: string;
+  createdAt?: string;
+  timing?: NarrationTiming;
+  viewport?: Viewport;
+  outputRoot?: string;
+  /**
+   * Per-move commentary text, keyed by 0-indexed move. When provided,
+   * each commentary item's `text` is filled in and the duration is
+   * estimated from the character count. Otherwise commentary items
+   * carry empty text and the floor duration.
+   */
+  commentaryByMoveIndex?: Record<number, string>;
+}
+
+/**
+ * Build a RenderPlan from a PGN string.
+ *
+ * The resulting plan interleaves move and commentary items in board
+ * order:
+ *
+ *   move 0 → commentary 0 → move 1 → commentary 1 → …
+ *
+ * A small `gap` item between move and commentary lets the board
+ * update animation settle before narration starts.
+ *
+ * Durations are PLANNED estimates; the capture pipeline re-times the
+ * plan from measured segment paint offsets after recording.
+ */
+export function createRenderPlanFromPgn(options: CreateRenderPlanOptions): RenderPlan {
+  const timing = options.timing ?? NATURAL_NARRATION_TIMING;
+  const viewport: Viewport = options.viewport ?? {
+    width: 1920,
+    height: 1080,
+    aspectRatio: '16:9',
+    deviceScaleFactor: 1,
+  };
+  const createdAt = options.createdAt ?? new Date().toISOString();
+  const game = parseSinglePgn(options.pgn);
+
+  const timeline: TimelineItem[] = [];
+  let cursor = 0;
+  let index = 0;
+  game.moves.forEach((move, moveIndex) => {
+    const moveItem: TimelineItem = {
+      index: index++,
+      kind: 'move',
+      startMs: cursor,
+      durationMs: timing.moveDurationMs,
+      moveIndex,
+      sanMove: move.san,
+      color: move.color,
+      fen: move.fen,
+    };
+    timeline.push(moveItem);
+    cursor += moveItem.durationMs;
+
+    const gapItem: TimelineItem = {
+      index: index++,
+      kind: 'gap',
+      startMs: cursor,
+      durationMs: timing.gapDurationMs,
+    };
+    timeline.push(gapItem);
+    cursor += gapItem.durationMs;
+
+    const text = options.commentaryByMoveIndex?.[moveIndex] ?? '';
+    const commentaryItem: TimelineItem = {
+      index: index++,
+      kind: 'commentary',
+      startMs: cursor,
+      durationMs: estimateCommentaryDurationMs(text, timing),
+      moveIndex,
+      sanMove: move.san,
+      color: move.color,
+      text,
+    };
+    timeline.push(commentaryItem);
+    cursor += commentaryItem.durationMs;
+  });
+
+  const lastItem = timeline[timeline.length - 1];
+  const endMs = lastItem ? lastItem.startMs + lastItem.durationMs : 0;
+  const slug = sanitizeSlug(options.episodeId ?? options.id);
+
+  const fullEpisode: RenderTarget = {
+    id: `${options.id}:full`,
+    kind: 'full',
+    viewport,
+    range: {
+      startMs: 0,
+      endMs,
+      endSegmentIndex: lastItem?.index ?? 0,
+    },
+    timeline,
+    artifact: {
+      fileName: `${slug}.mp4`,
+      durationMs: endMs,
+    },
+    outputPath: joinPath(options.outputRoot ?? 'exports', slug, `${slug}.mp4`),
+  };
+
+  return {
+    id: options.id,
+    runId: options.runId,
+    episodeId: options.episodeId,
+    title: options.title,
+    createdAt,
+    timing,
+    fullEpisode,
+    shorts: [],
+    pgnHeaders: { ...game.headers },
+    outputRoot: options.outputRoot,
+  };
+}
+
+function estimateCommentaryDurationMs(text: string, timing: NarrationTiming): number {
+  if (!text) return timing.textMinMs;
+  const estimated = text.length * timing.textMsPerChar;
+  return Math.min(timing.textMaxMs, Math.max(timing.textMinMs, estimated));
+}
+
+// ─── Retiming from measured offsets ─────────────────────────────────
+
+/**
+ * Map of {moveIndex → offsetMs from playback start}, populated by the
+ * broadcast bridge during capture. Keys are 0-indexed plies, matching
+ * the `maxMoveIndex` AudioNarrationQueue records when each commentary
+ * entry's first sentence begins playing.
+ */
+export type SegmentTimingsByMove = Record<number, number>;
+
+/**
+ * Given a render plan and a SegmentTimingsByMove map produced by the
+ * broadcast bridge, produce a new plan whose commentary start offsets
+ * and durations reflect what actually played. Items without a measured
+ * offset keep their planned values, anchored against the previous
+ * measured item where possible.
+ *
+ * The capture pipeline uses the retimed plan when composing the final
+ * audio track — caption / narration alignment within ~50 ms of paint.
+ */
+export function retimeRenderPlanWithSegmentTimings(
+  plan: RenderPlan,
+  timingsByMove: SegmentTimingsByMove,
+): RenderPlan {
+  const retimedTimeline = retimeTimeline(plan.fullEpisode.timeline, timingsByMove);
+  const lastItem = retimedTimeline[retimedTimeline.length - 1];
+  const endMs = lastItem ? lastItem.startMs + lastItem.durationMs : 0;
+  const retimedFull: RenderTarget = {
+    ...plan.fullEpisode,
+    timeline: retimedTimeline,
+    range: {
+      ...plan.fullEpisode.range,
+      endMs,
+      endSegmentIndex: lastItem?.index ?? plan.fullEpisode.range.endSegmentIndex,
+    },
+    artifact: {
+      ...plan.fullEpisode.artifact,
+      durationMs: endMs,
+    },
+  };
+  return {
+    ...plan,
+    fullEpisode: retimedFull,
+  };
+}
+
+function retimeTimeline(timeline: TimelineItem[], timingsByMove: SegmentTimingsByMove): TimelineItem[] {
+  // Anchor commentary items at their measured paint offsets when
+  // available. Move and gap items keep their planned durations but
+  // their startMs slides to sit immediately before the next measured
+  // commentary anchor. This preserves the move-before-commentary
+  // ordering while honoring the real audio clock.
+  //
+  // Walk the timeline once. Track a running cursor that advances by
+  // planned duration; whenever a measured anchor is encountered, snap
+  // the cursor to that anchor (with a sanity floor so we never go
+  // backward).
+  const result: TimelineItem[] = [];
+  let cursor = 0;
+  for (const item of timeline) {
+    const measured = measuredOffsetFor(item, timingsByMove);
+    const startMs = measured !== null ? Math.max(cursor, measured) : cursor;
+    const nextMeasured = findNextMeasuredAfter(timeline, timingsByMove, item.index);
+    const durationMs =
+      nextMeasured !== null && nextMeasured > startMs
+        ? nextMeasured - startMs
+        : item.durationMs;
+    result.push({ ...item, startMs, durationMs });
+    cursor = startMs + durationMs;
+  }
+  return result;
+}
+
+function measuredOffsetFor(item: TimelineItem, timingsByMove: SegmentTimingsByMove): number | null {
+  if (item.kind !== 'commentary' || item.moveIndex === undefined) return null;
+  const measured = timingsByMove[item.moveIndex];
+  return measured !== undefined ? measured : null;
+}
+
+function findNextMeasuredAfter(
+  timeline: TimelineItem[],
+  timingsByMove: SegmentTimingsByMove,
+  afterIndex: number,
+): number | null {
+  for (const item of timeline) {
+    if (item.index <= afterIndex) continue;
+    const measured = measuredOffsetFor(item, timingsByMove);
+    if (measured !== null) return measured;
+  }
+  return null;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function sanitizeSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
+function joinPath(...parts: string[]): string {
+  return parts.filter(Boolean).join('/');
+}
+
+// ─── Public re-exports for downstream consumers ────────────────────
+
+export type { PgnGame, PgnMove };

--- a/src/tts/audio-queue.ts
+++ b/src/tts/audio-queue.ts
@@ -21,10 +21,24 @@ interface QueueEntry {
   entryId?: string;
   maxMoveIndex?: number;
   moves?: NarrationMove[];
+  /**
+   * True when this sentence opens a new commentary entry (i.e. the
+   * board should advance and a render-plan paint offset should be
+   * recorded). Set by enqueueEntry for the first sentence only.
+   */
+  isEntryHead?: boolean;
 }
 
 export type SentenceStartCallback = (text: string, squares: string[], annotations: BoardAnnotations) => void;
 export type EntryStartCallback = (maxMoveIndex: number, moves: NarrationMove[], entryId: string) => void;
+/**
+ * Fires when the first sentence of a commentary entry begins playing.
+ * Receives the move index this entry covers and the offset from
+ * markPlaybackStart() in ms. Used only in broadcast / MP4-export mode.
+ * The export pipeline maps moveIndex → render-plan segment index when
+ * composing audio.
+ */
+export type SegmentStartCallback = (maxMoveIndex: number, offsetMs: number) => void;
 
 /**
  * Sequential audio narration queue with per-sentence board sync.
@@ -49,8 +63,18 @@ export class AudioNarrationQueue {
   private prefetchPromise: Promise<ArrayBuffer> | null = null;
   private onSentenceStart: SentenceStartCallback | null = null;
   private onEntryStart: EntryStartCallback | null = null;
+  private onSegmentStart: SegmentStartCallback | null = null;
   /** Tracks which entryId we last fired onEntryStart for. */
   private _lastFiredEntryId: string | null = null;
+  /**
+   * performance.now() at which __CHESS_EXPORT__.start() was called.
+   * Used to compute per-segment paint offsets in broadcast / MP4-export
+   * mode. Zero when not in broadcast mode (and onSegmentStart never
+   * fires).
+   */
+  private playbackStartMs = 0;
+  /** Tracks which moveIndex we last fired onSegmentStart for. */
+  private _lastFiredSegmentMoveIndex = -1;
 
   /** Number of commentary entries waiting or being played. */
   private _entryCount = 0;
@@ -87,6 +111,33 @@ export class AudioNarrationQueue {
   }
 
   /**
+   * Set callback fired when a sentence belonging to a known render-plan
+   * segment begins audio playback. Receives the segment index and the
+   * offset from markPlaybackStart() in ms.
+   *
+   * Used only in broadcast / MP4-export mode (Phase 2). The capture
+   * pipeline reads these offsets back through __CHESS_EXPORT__.state()
+   * and re-times the render plan so composed narration audio sits at
+   * the exact paint moment.
+   */
+  setSegmentStartCallback(cb: SegmentStartCallback | null): void {
+    this.onSegmentStart = cb;
+  }
+
+  /**
+   * Mark the moment __CHESS_EXPORT__.start() was called. All subsequent
+   * onSegmentStart offsets are measured from this point.
+   *
+   * No-op outside broadcast mode. Calling again with 0 disables segment
+   * timing emission for the rest of the queue's lifetime (used by the
+   * reset path).
+   */
+  markPlaybackStart(performanceNow: number): void {
+    this.playbackStartMs = performanceNow;
+    this._lastFiredSegmentMoveIndex = -1;
+  }
+
+  /**
    * Enqueue a full commentary entry with board-sync metadata.
    * Board advances only when this entry's first sentence starts playing.
    */
@@ -99,6 +150,7 @@ export class AudioNarrationQueue {
     const cleanText = stripMarkdownForTts(text);
     const sentences = splitIntoSentences(cleanText);
     this._entryCount++;
+    let firstSentenceOfEntry = true;
     for (const sentence of sentences) {
       const trimmed = sentence.trim();
       if (trimmed) {
@@ -115,7 +167,12 @@ export class AudioNarrationQueue {
           entryId: options.entryId,
           maxMoveIndex: options.maxMoveIndex,
           moves: options.moves,
+          // Only the first sentence of an entry is treated as the
+          // "head" — that's where the board advances and where the
+          // export pipeline records the segment paint offset.
+          isEntryHead: firstSentenceOfEntry,
         });
+        firstSentenceOfEntry = false;
       }
     }
     this.ensureProcessing();
@@ -304,6 +361,23 @@ export class AudioNarrationQueue {
         // Fire sentence start callback right before playback
         this.onSentenceStart?.(entry.text, entry.squares, entry.annotations);
 
+        // Fire segment-start callback when this sentence opens a new
+        // commentary entry AND we're in broadcast mode (markPlaybackStart
+        // has been called with a non-zero performance.now). Recorded
+        // once per moveIndex; the commentary entry's first sentence wins.
+        if (
+          entry.isEntryHead
+          && entry.maxMoveIndex !== undefined
+          && this.playbackStartMs > 0
+          && entry.maxMoveIndex !== this._lastFiredSegmentMoveIndex
+        ) {
+          this._lastFiredSegmentMoveIndex = entry.maxMoveIndex;
+          this.onSegmentStart?.(
+            entry.maxMoveIndex,
+            performance.now() - this.playbackStartMs,
+          );
+        }
+
         // Play the audio
         await this.playAudioBuffer(audioData);
       } catch (err) {
@@ -372,6 +446,31 @@ function stripMarkdownForTts(text: string): string {
     .replace(/\n{2,}/g, ' ')
     .replace(/\s{2,}/g, ' ')
     .trim();
+}
+
+// ─── Active-queue registry (broadcast mode) ─────────────────────────
+//
+// CommentaryPanel creates an AudioNarrationQueue per session. The
+// MP4-export pipeline (BroadcastView in Phase 1, scripts/lib/export in
+// Phase 3) needs to reach the currently-active queue to call
+// markPlaybackStart() and setSegmentStartCallback(). Following the
+// existing registerCommentaryQueue pattern in tournamentStore, expose
+// a module-level slot. Outside broadcast mode this slot is set but
+// nobody reads it.
+
+let activeAudioNarrationQueue: AudioNarrationQueue | null = null;
+
+/**
+ * Register the audio narration queue currently driving playback. Called
+ * by CommentaryPanel on mount. Unregister with null on unmount.
+ */
+export function registerAudioNarrationQueue(queue: AudioNarrationQueue | null): void {
+  activeAudioNarrationQueue = queue;
+}
+
+/** Returns the active audio narration queue, if any. */
+export function getActiveAudioNarrationQueue(): AudioNarrationQueue | null {
+  return activeAudioNarrationQueue;
 }
 
 /**


### PR DESCRIPTION
## Summary

Third slice of the MP4 game-review export pipeline (#36). Stacks on #39.

Headless Chromium drives broadcast mode end-to-end and produces a playable MP4 with one command.

### Smoke test

```
$ npm run export:game -- --episode opera_game_morphy_1858 --fast --preview=10
[export] vite ready at http://127.0.0.1:5173
[export] chromium launched
[capture] opening http://127.0.0.1:5173/?export=1&broadcast=1&episode=opera_game_morphy_1858...
[capture] recording started
[capture] captured 303 frames in 10.1 s
[ffmpeg] composing .../opera_game_morphy_1858_preview.mp4
[export] wrote exports/opera_game_morphy_1858/opera_game_morphy_1858_preview.mp4
```

174 KB playable MP4 in ~30 s wall clock.

### What this adds

- **`scripts/lib/export/devServer.ts`** spawns Vite directly via Node so tree-kill works on Windows (npm.cmd wrappers orphan grandchildren). Strips ANSI codes before matching the `Local: http` ready signal.
- **`scripts/lib/export/processRegistry.ts`** tracks PIDs of Vite / Chromium / ffmpeg and installs `SIGINT` / `SIGTERM` / `uncaughtException` handlers that `taskkill /t /f` on Windows. Ctrl+C cleans up the whole tree.
- **`scripts/lib/export/browserCapture.ts`** opens the SPA with `?export=1&broadcast=1&episode=<id>`, waits for `__CHESS_EXPORT__.state()` to report `{ ready, painted, broadcastMode, replayReady, audioReady }`, calls `reset()` and `start()`, streams CDP screencast frames, waits for `state().ended`, reads back `state().segmentTimings`.
- **`scripts/lib/export/frameSequenceWriter.ts`** buffers CDP frames keyed by arrival time, then on finalize emits a fixed-rate sequence (`frame_NNNNNNNN.jpg`). ffmpeg consumes with `-framerate 30` and the math just works.
- **`scripts/lib/export/ffmpegCompose.ts`** runs `ffmpeg-static` to encode the sequence to MP4 (H.264, yuv420p, faststart, CRF 20).
- **`scripts/export-chess-mp4.ts`** orchestrator. CLI flags:
  - `--episode <id>` — registered episode (default: `DEFAULT_EPISODE_ID`)
  - `--pgn <path>` — inline PGN file
  - `--fast` — lower JPEG quality (iteration loop)
  - `--preview=<seconds>` — hard-cap capture duration; output `<slug>_preview.mp4`
  - `--keep-frames` — keep temp frame dir after compose
  - `--output-root <dir>` — default `exports`
- **`npm run export:game`** wires it up.
- `ffmpeg-static` + `playwright` as devDependencies. Chromium installed via `npx playwright install chromium`.

### Output layout (matches Clio)

```
exports/<slug>/<slug>.mp4              full MP4 (or <slug>_preview.mp4 with --preview)
exports/<slug>/render-plan.json        retimed with measured segment offsets
exports/<slug>/render-manifest.json    frame count, durations, console errors
```

### Known limitations (follow-ups)

- **SILENT MP4 for now.** CDP screencast does not capture audio. The SPA plays TTS live during capture but the recording has no audio track. **Phase 3.1** will pre-render TTS clips Node-side with a content-hash cache (Clio-style) and compose them into the MP4 at measured `segmentTimings` offsets. `render-plan.json` already carries everything that step needs (per-move commentary text + paint offsets).
- **Without TTS enabled in the SPA**, replay runs at `moveDelayMs=0` and the game ends in milliseconds. Pipeline is correct; enable TTS in the SPA settings (persisted via localStorage) before kicking off the export to get a real video. A follow-up can pass TTS config through URL params.
- **Single-game capture only.** Shorts authoring lands in #37 (Phase 4).

### Test plan

- [x] `npm run build` — passes (no src/ changes in this PR)
- [x] `npm run lint` — clean on all 6 Phase 3 files
- [x] `npm run export:game -- --episode opera_game_morphy_1858 --fast --preview=10` → 174 KB MP4 in ~30 s
- [x] `Ctrl+C` mid-capture → Vite, Chromium, and ffmpeg all exit cleanly (no orphaned PIDs in Task Manager)
- [ ] Manual: enable TTS in the SPA settings, then `npm run export:game -- --episode opera_game_morphy_1858 --preview=60` → captures real narration timing into `segmentTimings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
