### PR TITLE
feat(mp4-export): Playwright capture + ffmpeg compose pipeline (Phase 3, #36)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,9 @@
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
+        "ffmpeg-static": "^5.3.0",
         "globals": "^16.5.0",
+        "playwright": "^1.60.0",
         "tailwindcss": "^4.2.1",
         "tsx": "^4.22.3",
         "typescript": "~5.9.3",
@@ -319,6 +321,22 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2386,6 +2404,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2501,6 +2532,13 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2531,6 +2569,13 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2641,6 +2686,22 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2770,6 +2831,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/esbuild": {
@@ -3076,6 +3147,23 @@
         }
       }
     },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3262,6 +3350,37 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3298,6 +3417,13 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -4516,6 +4642,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -4581,6 +4713,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -4631,6 +4810,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/property-information": {
@@ -4709,6 +4898,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/remark-parse": {
@@ -4799,6 +5003,27 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4856,6 +5081,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/stringify-entities": {
@@ -5501,6 +5736,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
-    "plan:game": "tsx scripts/export-render-plan.ts"
+    "plan:game": "tsx scripts/export-render-plan.ts",
+    "export:game": "tsx scripts/export-chess-mp4.ts"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
@@ -36,7 +37,9 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "ffmpeg-static": "^5.3.0",
     "globals": "^16.5.0",
+    "playwright": "^1.60.0",
     "tailwindcss": "^4.2.1",
     "tsx": "^4.22.3",
     "typescript": "~5.9.3",

--- a/scripts/export-chess-mp4.ts
+++ b/scripts/export-chess-mp4.ts
@@ -1,0 +1,238 @@
+/**
+ * scripts/export-chess-mp4.ts — produce a playable MP4 of any
+ * registered episode (or inline PGN) via headless-Chromium capture.
+ *
+ * Usage:
+ *   npm run export:game                                 # default episode
+ *   npm run export:game -- --episode opera_game_morphy_1858
+ *   npm run export:game -- --pgn matches/some.pgn
+ *   npm run export:game -- --episode <id> --fast
+ *   npm run export:game -- --episode <id> --preview=30
+ *   npm run export:game -- --episode <id> --keep-frames
+ *
+ * Output:
+ *   exports/<slug>/<slug>.mp4
+ *   exports/<slug>/render-plan.json      (retimed with measured offsets)
+ *   exports/<slug>/render-manifest.json  (frame count, durations, console errors)
+ *
+ * Phase 3 produces a SILENT mp4. Audio mux lands as a Phase 3.1
+ * follow-up — the SPA plays TTS live during capture, but CDP
+ * screencast does not capture audio. The render-plan.json + segment
+ * timings preserve everything the audio composition step needs.
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ffmpegStatic from 'ffmpeg-static';
+import { CHESS_EPISODES, DEFAULT_EPISODE_ID, getEpisode } from '../src/episodes';
+import {
+  createRenderPlanFromPgn,
+  retimeRenderPlanWithSegmentTimings,
+  type RenderPlan,
+} from '../src/production/renderPlan';
+import {
+  cleanupFrames,
+  launchBrowser,
+  recordBroadcastPlayback,
+} from './lib/export/browserCapture';
+import { startViteServer } from './lib/export/devServer';
+import { composeMp4 } from './lib/export/ffmpegCompose';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..');
+
+interface CliFlags {
+  pgnPath: string | null;
+  episodeId: string | null;
+  fastMode: boolean;
+  previewDurationMs: number | null;
+  keepFrames: boolean;
+  outputRoot: string;
+}
+
+function parseFlags(argv: string[]): CliFlags {
+  const flags: CliFlags = {
+    pgnPath: null,
+    episodeId: null,
+    fastMode: false,
+    previewDurationMs: null,
+    keepFrames: false,
+    outputRoot: 'exports',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--pgn') flags.pgnPath = argv[i + 1] ?? null;
+    else if (arg.startsWith('--pgn=')) flags.pgnPath = arg.slice('--pgn='.length);
+    else if (arg === '--episode') flags.episodeId = argv[i + 1] ?? null;
+    else if (arg.startsWith('--episode=')) flags.episodeId = arg.slice('--episode='.length);
+    else if (arg === '--fast') flags.fastMode = true;
+    else if (arg.startsWith('--preview=')) {
+      const sec = Number(arg.slice('--preview='.length));
+      if (Number.isFinite(sec) && sec > 0) flags.previewDurationMs = Math.round(sec * 1000);
+    } else if (arg === '--preview') {
+      const sec = Number(argv[i + 1]);
+      if (Number.isFinite(sec) && sec > 0) flags.previewDurationMs = Math.round(sec * 1000);
+    } else if (arg === '--keep-frames') flags.keepFrames = true;
+    else if (arg.startsWith('--output-root=')) flags.outputRoot = arg.slice('--output-root='.length);
+  }
+  return flags;
+}
+
+interface ResolvedInput {
+  pgnText: string;
+  title: string;
+  slug: string;
+  episodeId?: string;
+}
+
+async function resolveInput(flags: CliFlags): Promise<ResolvedInput> {
+  if (flags.pgnPath) {
+    const absolute = path.resolve(repoRoot, flags.pgnPath);
+    const pgnText = await readFile(absolute, 'utf8');
+    const base = path.basename(absolute, path.extname(absolute));
+    return {
+      pgnText,
+      title: base,
+      slug: base.toLowerCase().replace(/[^a-z0-9_-]+/g, '-'),
+    };
+  }
+  const id = flags.episodeId ?? DEFAULT_EPISODE_ID;
+  if (!id) {
+    throw new Error(
+      `No --pgn or --episode supplied and no default episode is registered. Available:\n  ${
+        CHESS_EPISODES.map((e) => e.id).join('\n  ') || '(none)'
+      }`,
+    );
+  }
+  const episode = getEpisode(id);
+  if (!episode) {
+    throw new Error(
+      `Unknown episode id "${id}". Available:\n  ${CHESS_EPISODES.map((e) => e.id).join('\n  ') || '(none)'}`,
+    );
+  }
+  return {
+    pgnText: episode.pgn,
+    title: episode.title,
+    slug: episode.id,
+    episodeId: episode.id,
+  };
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags(process.argv.slice(2));
+  const ffmpegPath = ffmpegStatic;
+  if (!ffmpegPath) {
+    throw new Error('ffmpeg-static did not resolve a binary path');
+  }
+  const input = await resolveInput(flags);
+  const slug = input.slug;
+  const createdAt = new Date().toISOString();
+
+  // Initial plan — planned durations only. Retimed after capture.
+  const initialPlan: RenderPlan = createRenderPlanFromPgn({
+    id: input.episodeId ?? `pgn:${slug}`,
+    runId: `run:${slug}:${createdAt}`,
+    title: input.title,
+    pgn: input.pgnText,
+    episodeId: input.episodeId,
+    createdAt,
+    outputRoot: flags.outputRoot,
+  });
+  const viewport = {
+    width: initialPlan.fullEpisode.viewport.width,
+    height: initialPlan.fullEpisode.viewport.height,
+    deviceScaleFactor: initialPlan.fullEpisode.viewport.deviceScaleFactor ?? 1,
+  };
+
+  // Working dirs.
+  const outDir = path.resolve(repoRoot, flags.outputRoot, slug);
+  const frameDir = path.resolve(repoRoot, '.tmp', 'export-frames', `${slug}-${Date.now().toString(36)}`);
+  await mkdir(outDir, { recursive: true });
+
+  console.log(`[export] ${input.title}`);
+  console.log(
+    `[export]   ${initialPlan.fullEpisode.timeline.length} segments, planned ${(initialPlan.fullEpisode.range.endMs / 1000).toFixed(1)} s, viewport ${viewport.width}x${viewport.height}`,
+  );
+  if (flags.fastMode) console.log('[export]   --fast (lower JPEG quality)');
+  if (flags.previewDurationMs) console.log(`[export]   --preview=${flags.previewDurationMs / 1000} s`);
+
+  let server: Awaited<ReturnType<typeof startViteServer>> | undefined;
+  let browser: Awaited<ReturnType<typeof launchBrowser>> | undefined;
+  try {
+    server = await startViteServer(repoRoot, '127.0.0.1', 5173);
+    console.log(`[export] vite ready at ${server.url}`);
+    browser = await launchBrowser();
+    console.log('[export] chromium launched');
+
+    const capture = await recordBroadcastPlayback(browser, {
+      serverUrl: server.url,
+      episodeId: input.episodeId,
+      rawPgn: input.episodeId ? undefined : input.pgnText,
+      frameDir,
+      viewport,
+      fastMode: flags.fastMode,
+      previewDurationMs: flags.previewDurationMs ?? undefined,
+    });
+
+    const retimedPlan = retimeRenderPlanWithSegmentTimings(initialPlan, capture.segmentTimings);
+    let outputPath = path.resolve(repoRoot, retimedPlan.fullEpisode.outputPath);
+    if (flags.previewDurationMs) {
+      outputPath = outputPath.replace(/\.mp4$/, '_preview.mp4');
+    }
+
+    await composeMp4({
+      frameDir: capture.frameDir,
+      frameRate: capture.frameRate,
+      outputPath,
+      ffmpegPath,
+    });
+
+    // Sidecar manifests.
+    await writeFile(
+      path.join(outDir, 'render-plan.json'),
+      `${JSON.stringify(retimedPlan, null, 2)}\n`,
+      'utf8',
+    );
+    await writeFile(
+      path.join(outDir, 'render-manifest.json'),
+      `${JSON.stringify(
+        {
+          slug,
+          title: input.title,
+          episodeId: input.episodeId,
+          createdAt,
+          outputPath: path.relative(repoRoot, outputPath),
+          fastMode: flags.fastMode,
+          previewDurationMs: flags.previewDurationMs,
+          capture: {
+            frameCount: capture.frameCount,
+            frameRate: capture.frameRate,
+            durationMs: capture.durationMs,
+            segmentTimingsCount: Object.keys(capture.segmentTimings).length,
+          },
+          consoleEntries: capture.consoleEntries.slice(-30),
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    console.log(`[export] wrote ${path.relative(repoRoot, outputPath)}`);
+    console.log(`[export] wrote ${path.relative(repoRoot, path.join(outDir, 'render-plan.json'))}`);
+    console.log(`[export] wrote ${path.relative(repoRoot, path.join(outDir, 'render-manifest.json'))}`);
+  } finally {
+    await Promise.allSettled([
+      browser?.close(),
+      server?.stop(),
+      cleanupFrames(frameDir, flags.keepFrames),
+    ]);
+  }
+}
+
+main().catch((err) => {
+  console.error('[export] failed:', err instanceof Error ? err.message : err);
+  if (err instanceof Error && err.stack) console.error(err.stack);
+  process.exit(1);
+});

--- a/scripts/lib/export/browserCapture.ts
+++ b/scripts/lib/export/browserCapture.ts
@@ -1,0 +1,250 @@
+/**
+ * Drive the SPA's broadcast mode from headless Chromium and capture
+ * frames via CDP Page.startScreencast.
+ *
+ * Lifted from Clio's scripts/lib/export/browserCapture.ts with a
+ * narrower surface:
+ *   - single viewport (no map prewarm, no basemap dance)
+ *   - single TTS provider hook (cloud Qwen / local Python server)
+ *   - chess-specific bridge name (__CHESS_EXPORT__)
+ */
+
+import { mkdir, rm } from 'node:fs/promises';
+import { chromium, type Browser, type Page } from 'playwright';
+import { registerPid } from './processRegistry';
+import { FrameSequenceWriter } from './frameSequenceWriter';
+
+const DEFAULT_FRAME_RATE = 30;
+const SCREENCAST_QUALITY_DEFAULT = 84;
+const SCREENCAST_QUALITY_FAST = 60;
+const EXPORT_READY_TIMEOUT_MS = 180_000;
+const CAPTURE_POSTROLL_MS = 500;
+
+export interface CaptureOptions {
+  /** Vite server URL, e.g. http://127.0.0.1:5173 */
+  serverUrl: string;
+  /** Episode id passed as ?episode=<id>. */
+  episodeId?: string;
+  /** Inline PGN passed as ?pgn=<encoded>. Mutually exclusive with episodeId. */
+  rawPgn?: string;
+  /** Output frame dir (absolute path). Will be created. */
+  frameDir: string;
+  /** Viewport for the capture. */
+  viewport: { width: number; height: number; deviceScaleFactor?: number };
+  /** Iteration / preview mode — lowers JPEG quality. */
+  fastMode?: boolean;
+  /**
+   * Optional hard cap on capture wall time. If set, capture stops at
+   * this duration regardless of whether the game has ended.
+   */
+  previewDurationMs?: number;
+  /**
+   * Maximum time to wait for state().ended before timing out.
+   * Defaults to plannedDurationMs * 1.5 + 5 minutes if not set.
+   */
+  endTimeoutMs?: number;
+}
+
+export interface CaptureResult {
+  frameDir: string;
+  frameCount: number;
+  frameRate: number;
+  /** Wall-clock duration of the recording, ms. */
+  durationMs: number;
+  /** Map of moveIndex → ms-from-start when each commentary entry began playing. */
+  segmentTimings: Record<number, number>;
+  /** Browser console errors / warnings collected during the run. */
+  consoleEntries: BrowserConsoleEntry[];
+}
+
+export interface BrowserConsoleEntry {
+  type: string;
+  text: string;
+}
+
+export async function recordBroadcastPlayback(browser: Browser, options: CaptureOptions): Promise<CaptureResult> {
+  await mkdir(options.frameDir, { recursive: true });
+  const context = await browser.newContext({
+    viewport: { width: options.viewport.width, height: options.viewport.height },
+    deviceScaleFactor: options.viewport.deviceScaleFactor ?? 1,
+    colorScheme: 'dark',
+    reducedMotion: 'no-preference',
+  });
+  const page = await context.newPage();
+  const consoleEntries: BrowserConsoleEntry[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error' || message.type() === 'warning') {
+      consoleEntries.push({ type: message.type(), text: message.text() });
+    }
+  });
+  page.on('pageerror', (error) => {
+    const stack = error.stack && error.stack !== error.message ? `\n${error.stack}` : '';
+    consoleEntries.push({ type: 'pageerror', text: `${error.message}${stack}` });
+  });
+
+  try {
+    const url = buildUrl(options);
+    console.log(`[capture] opening ${url} at ${options.viewport.width}x${options.viewport.height}`);
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: EXPORT_READY_TIMEOUT_MS });
+    await waitForExportBridge(page);
+
+    // Bridge is ready; reset state and prepare frame writer.
+    await page.evaluate(() => window.__CHESS_EXPORT__?.reset());
+    await page.waitForTimeout(250);
+
+    const frameWriter = new FrameSequenceWriter({
+      frameDir: options.frameDir,
+      frameRate: DEFAULT_FRAME_RATE,
+    });
+
+    const client = await context.newCDPSession(page);
+    client.on('Page.screencastFrame', (event) => {
+      frameWriter.ingest(event.data, Date.now());
+      void client.send('Page.screencastFrameAck', { sessionId: event.sessionId }).catch(() => undefined);
+    });
+    await client.send('Page.startScreencast', {
+      format: 'jpeg',
+      quality: options.fastMode ? SCREENCAST_QUALITY_FAST : SCREENCAST_QUALITY_DEFAULT,
+      everyNthFrame: 1,
+    });
+
+    const startedAtMs = Date.now();
+    frameWriter.start(startedAtMs);
+    await page.evaluate(() => window.__CHESS_EXPORT__?.start());
+    console.log('[capture] recording started');
+
+    await waitForPlaybackEnd(page, options);
+    const endedAtMs = Date.now();
+    await page.waitForTimeout(CAPTURE_POSTROLL_MS);
+    await client.send('Page.stopScreencast').catch(() => undefined);
+
+    const durationMs = Math.max(1000, endedAtMs - startedAtMs);
+    const frameCount = await frameWriter.finalize(durationMs);
+
+    // Read segment timings + render plan diagnostic back out.
+    const segmentTimings =
+      (await page
+        .evaluate(() => window.__CHESS_EXPORT__?.state().segmentTimings ?? {})
+        .catch(() => ({}))) ?? {};
+
+    console.log(
+      `[capture] captured ${frameCount} frames in ${(durationMs / 1000).toFixed(1)} s, ${
+        Object.keys(segmentTimings).length
+      } segment timings`,
+    );
+    if (Object.keys(segmentTimings).length === 0) {
+      console.warn(
+        '[capture] no segment timings captured — audio will use planned offsets (may drift); is TTS enabled in the SPA settings?',
+      );
+    }
+
+    return {
+      frameDir: options.frameDir,
+      frameCount,
+      frameRate: DEFAULT_FRAME_RATE,
+      durationMs,
+      segmentTimings,
+      consoleEntries,
+    };
+  } finally {
+    await context.close().catch(() => undefined);
+  }
+}
+
+function buildUrl(options: CaptureOptions): string {
+  const url = new URL(options.serverUrl);
+  url.searchParams.set('export', '1');
+  url.searchParams.set('broadcast', '1');
+  if (options.episodeId) url.searchParams.set('episode', options.episodeId);
+  if (options.rawPgn) url.searchParams.set('pgn', options.rawPgn);
+  url.searchParams.set('w', String(options.viewport.width));
+  url.searchParams.set('h', String(options.viewport.height));
+  return url.toString();
+}
+
+async function waitForExportBridge(page: Page): Promise<void> {
+  // Steady-state gate: bridge installed, page mounted, painted at
+  // least once, audio context ready, replay runtime ready.
+  await page.waitForFunction(
+    () => {
+      const bridge = window.__CHESS_EXPORT__;
+      if (!bridge) return false;
+      const state = bridge.state();
+      return state.ready && state.broadcastMode && state.painted && state.replayReady && state.audioReady;
+    },
+    undefined,
+    { timeout: EXPORT_READY_TIMEOUT_MS },
+  );
+}
+
+async function waitForPlaybackEnd(page: Page, options: CaptureOptions): Promise<void> {
+  if (options.previewDurationMs !== undefined) {
+    // Preview mode races a hard cap against the natural end signal.
+    const donePromise = page
+      .waitForFunction(() => Boolean(window.__CHESS_EXPORT__?.state().ended), undefined, {
+        timeout: options.previewDurationMs + 60_000,
+      })
+      .catch(() => undefined);
+    await Promise.race([donePromise, page.waitForTimeout(options.previewDurationMs)]);
+    return;
+  }
+  // Game-review captures: be generous with the timeout. A Morphy
+  // game is ~3 minutes of moves but commentary at high reasoning
+  // effort can easily push 30 minutes. The default 60-minute ceiling
+  // is intentionally large; override via endTimeoutMs.
+  const timeout = options.endTimeoutMs ?? 60 * 60_000;
+  await page.waitForFunction(
+    () => Boolean(window.__CHESS_EXPORT__?.state().ended),
+    undefined,
+    { timeout },
+  );
+}
+
+export async function launchBrowser(): Promise<Browser> {
+  const args = [
+    '--autoplay-policy=no-user-gesture-required',
+    '--disable-background-timer-throttling',
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding',
+    '--hide-scrollbars',
+  ];
+  const browser = await chromium.launch({ headless: true, args });
+  try {
+    const proc = (browser as unknown as { process?: () => { pid?: number } | null }).process?.();
+    if (proc?.pid !== undefined) {
+      const unregister = registerPid(proc.pid);
+      browser.once('disconnected', unregister);
+    }
+  } catch {
+    // chromium-headless-shell sometimes doesn't expose process(); the
+    // browser still works, we just lose the tree-kill safety net for
+    // the chromium subtree. browser.close() in the orchestrator's
+    // finally block remains the primary cleanup.
+  }
+  return browser;
+}
+
+export async function cleanupFrames(frameDir: string, keep: boolean): Promise<void> {
+  if (keep) return;
+  await rm(frameDir, { recursive: true, force: true });
+}
+
+// Augment the window type for TS callers inside page.evaluate().
+declare global {
+  interface Window {
+    __CHESS_EXPORT__?: {
+      reset(): void;
+      start(): void;
+      state(): {
+        ready: boolean;
+        painted: boolean;
+        broadcastMode: boolean;
+        replayReady: boolean;
+        audioReady: boolean;
+        ended: boolean;
+        segmentTimings: Record<number, number>;
+        renderPlan?: unknown;
+      };
+    };
+  }
+}

--- a/scripts/lib/export/devServer.ts
+++ b/scripts/lib/export/devServer.ts
@@ -1,0 +1,136 @@
+/**
+ * Spawn Vite directly so tree-kill works on Windows.
+ *
+ * `npm run dev` wraps Vite in npm.cmd → node, which on Windows
+ * orphans children when the parent is killed. Spawning vite.js
+ * directly via Node keeps the process tree under our control so
+ * Ctrl+C / signal handlers can clean up reliably.
+ *
+ * Adapted from Clio's scripts/lib/export/devServer.ts with a
+ * narrower surface — we only need a single instance per export run.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { registerPid } from './processRegistry';
+
+export interface ViteServer {
+  url: string;
+  port: number;
+  host: string;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Resolve the local Vite entry script via createRequire so we
+ * launch the workspace's exact version, not whatever's on PATH.
+ */
+function resolveViteBin(cwd: string): string {
+  const require = createRequire(path.join(cwd, 'package.json'));
+  // Vite ships its CLI entry as bin/vite.js. The package.json `bin`
+  // field maps "vite" → "bin/vite.js"; resolving the package then
+  // joining is more robust than relying on `require.resolve('vite/bin/vite.js')`
+  // which fails when the host project has a different export map.
+  const vitePkg = require.resolve('vite/package.json');
+  return path.join(path.dirname(vitePkg), 'bin', 'vite.js');
+}
+
+export async function startViteServer(
+  cwd: string,
+  host: string,
+  port: number,
+): Promise<ViteServer> {
+  const viteBin = resolveViteBin(cwd);
+  const args = [viteBin, '--host', host, '--port', String(port), '--strictPort'];
+
+  const child = spawn(process.execPath, args, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, FORCE_COLOR: '0' },
+    windowsHide: true,
+  });
+
+  if (child.pid !== undefined) {
+    const unregister = registerPid(child.pid);
+    child.once('exit', unregister);
+  }
+
+  const url = await waitForViteReady(child, host, port);
+  return {
+    url,
+    port,
+    host,
+    stop: () => stopProcess(child),
+  };
+}
+
+function waitForViteReady(child: ChildProcess, host: string, port: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const READY_TIMEOUT_MS = 120_000;
+    const startedAt = Date.now();
+    let resolved = false;
+    let buffered = '';
+
+    const timer = setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      reject(new Error(`Vite did not become ready within ${READY_TIMEOUT_MS} ms\n--- output ---\n${buffered.slice(-2000)}`));
+    }, READY_TIMEOUT_MS);
+
+    const onData = (chunk: Buffer | string) => {
+      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      buffered += text;
+      if (resolved) return;
+      // Vite prints "Local:   http://localhost:5173/" once ready, but
+      // the line is colored — strip ANSI escape codes before matching.
+      // Use the standard ANSI CSI / OSC sequence pattern.
+      // eslint-disable-next-line no-control-regex
+      const clean = buffered.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
+      if (/Local:\s+http/i.test(clean)) {
+        resolved = true;
+        clearTimeout(timer);
+        resolve(`http://${host}:${port}`);
+      }
+    };
+
+    child.stdout?.on('data', onData);
+    child.stderr?.on('data', onData);
+    child.once('exit', (code) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
+      reject(
+        new Error(
+          `Vite exited with code ${code} before becoming ready after ${Date.now() - startedAt} ms\n--- output ---\n${buffered.slice(-2000)}`,
+        ),
+      );
+    });
+  });
+}
+
+function stopProcess(child: ChildProcess): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+      return;
+    }
+    child.once('exit', () => resolve());
+    // On Windows, kill the whole tree via taskkill — sending SIGTERM
+    // to a Node child sometimes leaves Vite's esbuild service alive.
+    if (process.platform === 'win32' && child.pid !== undefined) {
+      spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      }).on('exit', () => resolve());
+    } else {
+      child.kill('SIGTERM');
+      // Backstop: SIGKILL after a second if it hasn't exited.
+      setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGKILL');
+        }
+      }, 1000);
+    }
+  });
+}

--- a/scripts/lib/export/ffmpegCompose.ts
+++ b/scripts/lib/export/ffmpegCompose.ts
@@ -1,0 +1,88 @@
+/**
+ * Compose a frame sequence + (optional) narration audio into an MP4
+ * via ffmpeg-static. No audio mixing in Phase 3 — the SPA plays TTS
+ * live during capture but the audio is NOT recorded by CDP screencast;
+ * we emit a silent MP4 for now. A follow-up can add pre-rendered
+ * TTS clips composed at segmentTimings offsets (Clio's pattern).
+ *
+ * Silent-MP4-first keeps Phase 3 reviewable. Audio mux lands as a
+ * Phase 3.1 follow-up after Phase 3 merges.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { registerPid } from './processRegistry';
+
+export interface ComposeOptions {
+  /** Absolute path to a directory containing frame_00000000.jpg, frame_00000001.jpg, … */
+  frameDir: string;
+  /** Frame rate matching the writer's output (typically 30). */
+  frameRate: number;
+  /** Absolute output path for the .mp4 file. */
+  outputPath: string;
+  /** Absolute path to the ffmpeg binary. */
+  ffmpegPath: string;
+}
+
+/**
+ * Run ffmpeg to encode the frame sequence into a playable MP4.
+ *
+ * Args breakdown:
+ *   -framerate <rate>         expected input frame rate
+ *   -i frame_%08d.jpg         glob of JPEG inputs
+ *   -c:v libx264              widely-supported H.264 encoder
+ *   -pix_fmt yuv420p          required for QuickTime / browser playback
+ *   -movflags +faststart      enables streaming (metadata at file head)
+ *   -preset veryfast          balance speed vs. file size; iteration friendly
+ *   -crf 20                   visually transparent quality (good for code text)
+ *   -y                        overwrite output without prompting
+ */
+export async function composeMp4(options: ComposeOptions): Promise<void> {
+  await mkdir(path.dirname(options.outputPath), { recursive: true });
+  const args = [
+    '-y',
+    '-framerate',
+    String(options.frameRate),
+    '-i',
+    path.join(options.frameDir, 'frame_%08d.jpg'),
+    '-c:v',
+    'libx264',
+    '-pix_fmt',
+    'yuv420p',
+    '-movflags',
+    '+faststart',
+    '-preset',
+    'veryfast',
+    '-crf',
+    '20',
+    options.outputPath,
+  ];
+  console.log(`[ffmpeg] composing ${options.outputPath}`);
+  await runFfmpeg(options.ffmpegPath, args);
+}
+
+function runFfmpeg(ffmpegPath: string, args: string[]): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child: ChildProcess = spawn(ffmpegPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    if (child.pid !== undefined) {
+      const unregister = registerPid(child.pid);
+      child.once('exit', unregister);
+    }
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`ffmpeg exited with code ${code}\n--- stderr tail ---\n${stderr.slice(-2000)}`));
+      }
+    });
+  });
+}

--- a/scripts/lib/export/frameSequenceWriter.ts
+++ b/scripts/lib/export/frameSequenceWriter.ts
@@ -1,0 +1,96 @@
+/**
+ * Buffers JPEG screencast frames to disk at a fixed frame rate.
+ *
+ * CDP Page.startScreencast emits frames as base64 JPEGs at whatever
+ * rate Chromium decides (typically 30 fps when motion is heavy,
+ * dropping when the page is idle). For ffmpeg we need a regular
+ * frame sequence — frame_NNNNNNNN.jpg where N is the playback time
+ * divided by the frame interval.
+ *
+ * Approach: ingest frames keyed by their arrival timestamp (ms from
+ * record start), then on finalize, replay the buffer to emit one
+ * frame per fixed interval, repeating the most-recent frame when
+ * Chromium dropped one. ffmpeg consumes the resulting sequence with
+ * `-framerate <rate>` and the math just works.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export interface FrameSequenceWriterOptions {
+  /** Absolute directory where frames are written. Must already exist. */
+  frameDir: string;
+  /** Target frame rate; the output sequence has one file per 1/N seconds. */
+  frameRate: number;
+}
+
+interface BufferedFrame {
+  data: Buffer;
+  receivedMs: number;
+}
+
+export class FrameSequenceWriter {
+  private readonly frameDir: string;
+  private readonly frameRate: number;
+  private readonly intervalMs: number;
+  private startedAtMs = 0;
+  private buffer: BufferedFrame[] = [];
+
+  constructor(options: FrameSequenceWriterOptions) {
+    this.frameDir = options.frameDir;
+    this.frameRate = options.frameRate;
+    this.intervalMs = 1000 / options.frameRate;
+  }
+
+  /** Begin accepting frames. receivedMs is measured from this point. */
+  start(startedAtMs: number): void {
+    this.startedAtMs = startedAtMs;
+    this.buffer = [];
+  }
+
+  /**
+   * Ingest a screencast frame. base64Data is the raw CDP payload;
+   * receivedAtMs is Date.now() at receipt time.
+   */
+  ingest(base64Data: string, receivedAtMs: number): void {
+    if (this.startedAtMs === 0) return;
+    this.buffer.push({
+      data: Buffer.from(base64Data, 'base64'),
+      receivedMs: receivedAtMs - this.startedAtMs,
+    });
+  }
+
+  /**
+   * Stop accepting frames, emit the fixed-rate sequence to disk.
+   * Returns the number of frames written.
+   *
+   * Emission rule: for each output slot at time T = i * intervalMs,
+   * pick the most-recent buffered frame whose receivedMs <= T. When
+   * Chromium dropped frames (T < first receivedMs), use the first
+   * frame as a placeholder.
+   */
+  async finalize(captureDurationMs: number): Promise<number> {
+    if (this.buffer.length === 0) {
+      throw new Error('FrameSequenceWriter: no frames were ingested');
+    }
+    // Sort defensively — events should arrive in order, but a stray
+    // race in CDP delivery isn't impossible.
+    const sorted = [...this.buffer].sort((a, b) => a.receivedMs - b.receivedMs);
+
+    const frameCount = Math.max(1, Math.round((captureDurationMs / 1000) * this.frameRate));
+    let cursor = 0; // index into `sorted` of the current "active" frame
+    const writes: Promise<void>[] = [];
+    for (let i = 0; i < frameCount; i++) {
+      const slotMs = i * this.intervalMs;
+      // Advance the cursor to the latest frame whose timestamp <= slotMs.
+      while (cursor + 1 < sorted.length && sorted[cursor + 1].receivedMs <= slotMs) {
+        cursor++;
+      }
+      const frame = sorted[cursor];
+      const file = path.join(this.frameDir, `frame_${String(i).padStart(8, '0')}.jpg`);
+      writes.push(writeFile(file, frame.data));
+    }
+    await Promise.all(writes);
+    return frameCount;
+  }
+}

--- a/scripts/lib/export/processRegistry.ts
+++ b/scripts/lib/export/processRegistry.ts
@@ -1,0 +1,72 @@
+/**
+ * Tracks PIDs of long-running children (Vite, Chromium, ffmpeg) so
+ * the export script's signal handlers can tree-kill them on Ctrl+C.
+ *
+ * On Windows, killing a Node child with SIGTERM doesn't propagate to
+ * grandchildren (esbuild, chromium renderers, etc.) — they orphan.
+ * The signal handlers walk the registry and call `taskkill /t /f`.
+ *
+ * Mirrors Clio's scripts/lib/export/processRegistry.ts narrowly:
+ * just the PID set, the register/unregister API, and the signal
+ * handlers. No watchdog, no idle-timeout, no per-process metadata.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+const tracked = new Set<number>();
+let handlersInstalled = false;
+
+/**
+ * Register a PID. Returns an unregister function to call when the
+ * process exits normally. Idempotent.
+ */
+export function registerPid(pid: number): () => void {
+  tracked.add(pid);
+  installHandlersOnce();
+  return () => {
+    tracked.delete(pid);
+  };
+}
+
+/** Kill all tracked PIDs immediately (best-effort tree-kill). */
+export function killAllTracked(): void {
+  for (const pid of tracked) {
+    try {
+      if (process.platform === 'win32') {
+        spawnSync('taskkill', ['/pid', String(pid), '/t', '/f'], {
+          stdio: 'ignore',
+          windowsHide: true,
+        });
+      } else {
+        process.kill(pid, 'SIGTERM');
+      }
+    } catch {
+      // Process may already be dead; ignore.
+    }
+  }
+  tracked.clear();
+}
+
+function installHandlersOnce(): void {
+  if (handlersInstalled) return;
+  handlersInstalled = true;
+  // SIGINT (Ctrl+C) and SIGTERM (graceful kill from a parent) both
+  // route through the same cleanup. The handler is synchronous —
+  // async cleanup is unreliable from signal handlers, and taskkill
+  // /f is effectively synchronous anyway.
+  const handle = (signal: NodeJS.Signals): void => {
+    killAllTracked();
+    // Re-raise so the default behaviour (exit) still happens.
+    process.kill(process.pid, signal);
+  };
+  process.once('SIGINT', () => handle('SIGINT'));
+  process.once('SIGTERM', () => handle('SIGTERM'));
+  // uncaughtException keeps the cleanup running on a programming
+  // error — without it, Vite/Chromium orphan when the script throws.
+  process.once('uncaughtException', (err) => {
+    console.error('[export] uncaught exception, cleaning up children');
+    console.error(err);
+    killAllTracked();
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Third slice of the MP4 game-review export pipeline (#36). Stacks on #39.

Headless Chromium drives broadcast mode end-to-end and produces a playable MP4 with one command.

### Smoke test

```
$ npm run export:game -- --episode opera_game_morphy_1858 --fast --preview=10
[export] vite ready at http://127.0.0.1:5173
[export] chromium launched
[capture] opening http://127.0.0.1:5173/?export=1&broadcast=1&episode=opera_game_morphy_1858...
[capture] recording started
[capture] captured 303 frames in 10.1 s
[ffmpeg] composing .../opera_game_morphy_1858_preview.mp4
[export] wrote exports/opera_game_morphy_1858/opera_game_morphy_1858_preview.mp4
```

174 KB playable MP4 in ~30 s wall clock.

### What this adds

- **`scripts/lib/export/devServer.ts`** spawns Vite directly via Node so tree-kill works on Windows (npm.cmd wrappers orphan grandchildren). Strips ANSI codes before matching the `Local: http` ready signal.
- **`scripts/lib/export/processRegistry.ts`** tracks PIDs of Vite / Chromium / ffmpeg and installs `SIGINT` / `SIGTERM` / `uncaughtException` handlers that `taskkill /t /f` on Windows. Ctrl+C cleans up the whole tree.
- **`scripts/lib/export/browserCapture.ts`** opens the SPA with `?export=1&broadcast=1&episode=<id>`, waits for `__CHESS_EXPORT__.state()` to report `{ ready, painted, broadcastMode, replayReady, audioReady }`, calls `reset()` and `start()`, streams CDP screencast frames, waits for `state().ended`, reads back `state().segmentTimings`.
- **`scripts/lib/export/frameSequenceWriter.ts`** buffers CDP frames keyed by arrival time, then on finalize emits a fixed-rate sequence (`frame_NNNNNNNN.jpg`). ffmpeg consumes with `-framerate 30` and the math just works.
- **`scripts/lib/export/ffmpegCompose.ts`** runs `ffmpeg-static` to encode the sequence to MP4 (H.264, yuv420p, faststart, CRF 20).
- **`scripts/export-chess-mp4.ts`** orchestrator. CLI flags:
  - `--episode <id>` — registered episode (default: `DEFAULT_EPISODE_ID`)
  - `--pgn <path>` — inline PGN file
  - `--fast` — lower JPEG quality (iteration loop)
  - `--preview=<seconds>` — hard-cap capture duration; output `<slug>_preview.mp4`
  - `--keep-frames` — keep temp frame dir after compose
  - `--output-root <dir>` — default `exports`
- **`npm run export:game`** wires it up.
- `ffmpeg-static` + `playwright` as devDependencies. Chromium installed via `npx playwright install chromium`.

### Output layout (matches Clio)

```
exports/<slug>/<slug>.mp4              full MP4 (or <slug>_preview.mp4 with --preview)
exports/<slug>/render-plan.json        retimed with measured segment offsets
exports/<slug>/render-manifest.json    frame count, durations, console errors
```

### Known limitations (follow-ups)

- **SILENT MP4 for now.** CDP screencast does not capture audio. The SPA plays TTS live during capture but the recording has no audio track. **Phase 3.1** will pre-render TTS clips Node-side with a content-hash cache (Clio-style) and compose them into the MP4 at measured `segmentTimings` offsets. `render-plan.json` already carries everything that step needs (per-move commentary text + paint offsets).
- **Without TTS enabled in the SPA**, replay runs at `moveDelayMs=0` and the game ends in milliseconds. Pipeline is correct; enable TTS in the SPA settings (persisted via localStorage) before kicking off the export to get a real video. A follow-up can pass TTS config through URL params.
- **Single-game capture only.** Shorts authoring lands in #37 (Phase 4).

### Test plan

- [x] `npm run build` — passes (no src/ changes in this PR)
- [x] `npm run lint` — clean on all 6 Phase 3 files
- [x] `npm run export:game -- --episode opera_game_morphy_1858 --fast --preview=10` → 174 KB MP4 in ~30 s
- [x] `Ctrl+C` mid-capture → Vite, Chromium, and ffmpeg all exit cleanly (no orphaned PIDs in Task Manager)
- [ ] Manual: enable TTS in the SPA settings, then `npm run export:game -- --episode opera_game_morphy_1858 --preview=60` → captures real narration timing into `segmentTimings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
