### PR TITLE
feat(mp4-export): authored-shorts capture (Phase 4, #37)

### DIFF
--- a/scripts/export-chess-mp4.ts
+++ b/scripts/export-chess-mp4.ts
@@ -26,11 +26,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ffmpegStatic from 'ffmpeg-static';
 import { CHESS_EPISODES, DEFAULT_EPISODE_ID, getEpisode } from '../src/episodes';
+import type { EpisodeShortClip } from '../src/episodes/types';
 import {
   createRenderPlanFromPgn,
   retimeRenderPlanWithSegmentTimings,
   type RenderPlan,
 } from '../src/production/renderPlan';
+import { shortClipToRenderTarget, SHORTS_VIEWPORT } from '../src/production/clipManifest';
 import {
   cleanupFrames,
   launchBrowser,
@@ -49,6 +51,10 @@ interface CliFlags {
   previewDurationMs: number | null;
   keepFrames: boolean;
   outputRoot: string;
+  /** When set, capture only these specific authored shorts (and skip full). */
+  shortIds: string[];
+  /** When true, capture every authored short (and skip full). */
+  allShorts: boolean;
 }
 
 function parseFlags(argv: string[]): CliFlags {
@@ -59,6 +65,8 @@ function parseFlags(argv: string[]): CliFlags {
     previewDurationMs: null,
     keepFrames: false,
     outputRoot: 'exports',
+    shortIds: [],
+    allShorts: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -75,6 +83,14 @@ function parseFlags(argv: string[]): CliFlags {
       if (Number.isFinite(sec) && sec > 0) flags.previewDurationMs = Math.round(sec * 1000);
     } else if (arg === '--keep-frames') flags.keepFrames = true;
     else if (arg.startsWith('--output-root=')) flags.outputRoot = arg.slice('--output-root='.length);
+    else if (arg === '--all-shorts') flags.allShorts = true;
+    else if (arg === '--short' || arg === '--shorts') {
+      const value = argv[i + 1];
+      if (value) flags.shortIds.push(...value.split(',').map((s) => s.trim()).filter(Boolean));
+    } else if (arg.startsWith('--short=') || arg.startsWith('--shorts=')) {
+      const value = arg.slice(arg.indexOf('=') + 1);
+      if (value) flags.shortIds.push(...value.split(',').map((s) => s.trim()).filter(Boolean));
+    }
   }
   return flags;
 }
@@ -84,6 +100,8 @@ interface ResolvedInput {
   title: string;
   slug: string;
   episodeId?: string;
+  /** Authored shorts available for this input. Empty for raw-PGN inputs. */
+  authoredShorts: EpisodeShortClip[];
 }
 
 async function resolveInput(flags: CliFlags): Promise<ResolvedInput> {
@@ -95,6 +113,7 @@ async function resolveInput(flags: CliFlags): Promise<ResolvedInput> {
       pgnText,
       title: base,
       slug: base.toLowerCase().replace(/[^a-z0-9_-]+/g, '-'),
+      authoredShorts: [],
     };
   }
   const id = flags.episodeId ?? DEFAULT_EPISODE_ID;
@@ -116,6 +135,46 @@ async function resolveInput(flags: CliFlags): Promise<ResolvedInput> {
     title: episode.title,
     slug: episode.id,
     episodeId: episode.id,
+    authoredShorts: episode.exports?.shorts ?? [],
+  };
+}
+
+/**
+ * Filter the authored-shorts list according to CLI flags.
+ *
+ *   --all-shorts          → include every authored short, skip full
+ *   --short=<id1,id2>     → include only the named clips, skip full
+ *   (neither)             → no shorts captured; full only
+ *
+ * Returns `{ shorts, skipFull }`. Throws on unknown clip ids.
+ */
+function selectShorts(
+  flags: CliFlags,
+  authored: EpisodeShortClip[],
+): { shorts: EpisodeShortClip[]; skipFull: boolean } {
+  if (!flags.allShorts && flags.shortIds.length === 0) {
+    return { shorts: [], skipFull: false };
+  }
+  if (authored.length === 0) {
+    throw new Error(
+      '--short / --all-shorts was requested but the resolved input has no authored shorts.',
+    );
+  }
+  if (flags.allShorts) {
+    return { shorts: [...authored], skipFull: true };
+  }
+  const known = new Map(authored.map((s) => [s.id, s]));
+  const missing = flags.shortIds.filter((id) => !known.has(id));
+  if (missing.length > 0) {
+    throw new Error(
+      `--short referenced unknown clip id(s): ${missing.join(', ')}. Available: ${[...known.keys()].join(
+        ', ',
+      )}`,
+    );
+  }
+  return {
+    shorts: flags.shortIds.map((id) => known.get(id) as EpisodeShortClip),
+    skipFull: true,
   };
 }
 
@@ -145,9 +204,11 @@ async function main(): Promise<void> {
     deviceScaleFactor: initialPlan.fullEpisode.viewport.deviceScaleFactor ?? 1,
   };
 
+  // Phase 4: select shorts based on CLI flags.
+  const { shorts: selectedShorts, skipFull } = selectShorts(flags, input.authoredShorts);
+
   // Working dirs.
   const outDir = path.resolve(repoRoot, flags.outputRoot, slug);
-  const frameDir = path.resolve(repoRoot, '.tmp', 'export-frames', `${slug}-${Date.now().toString(36)}`);
   await mkdir(outDir, { recursive: true });
 
   console.log(`[export] ${input.title}`);
@@ -156,39 +217,101 @@ async function main(): Promise<void> {
   );
   if (flags.fastMode) console.log('[export]   --fast (lower JPEG quality)');
   if (flags.previewDurationMs) console.log(`[export]   --preview=${flags.previewDurationMs / 1000} s`);
+  if (skipFull) console.log(`[export]   shorts mode: ${selectedShorts.map((s) => s.id).join(', ')}`);
+  else if (input.authoredShorts.length > 0) console.log(`[export]   ${input.authoredShorts.length} authored short(s) available (skipped; pass --all-shorts to include)`);
 
   let server: Awaited<ReturnType<typeof startViteServer>> | undefined;
   let browser: Awaited<ReturnType<typeof launchBrowser>> | undefined;
+  const frameDirs: string[] = [];
   try {
     server = await startViteServer(repoRoot, '127.0.0.1', 5173);
     console.log(`[export] vite ready at ${server.url}`);
     browser = await launchBrowser();
     console.log('[export] chromium launched');
 
-    const capture = await recordBroadcastPlayback(browser, {
-      serverUrl: server.url,
-      episodeId: input.episodeId,
-      rawPgn: input.episodeId ? undefined : input.pgnText,
-      frameDir,
-      viewport,
-      fastMode: flags.fastMode,
-      previewDurationMs: flags.previewDurationMs ?? undefined,
-    });
-
-    const retimedPlan = retimeRenderPlanWithSegmentTimings(initialPlan, capture.segmentTimings);
-    let outputPath = path.resolve(repoRoot, retimedPlan.fullEpisode.outputPath);
-    if (flags.previewDurationMs) {
-      outputPath = outputPath.replace(/\.mp4$/, '_preview.mp4');
+    // Targets array. The orchestrator captures them sequentially with
+    // a fresh browser context per target — parallel capture is a
+    // follow-up (Clio pattern); chess captures are short enough that
+    // serial is acceptable for Phase 4.
+    interface CaptureJob {
+      label: string;
+      shortId?: string;
+      viewport: { width: number; height: number; deviceScaleFactor?: number };
+      outputPath: string;
+    }
+    const jobs: CaptureJob[] = [];
+    if (!skipFull) {
+      let outputPath = path.resolve(repoRoot, initialPlan.fullEpisode.outputPath);
+      if (flags.previewDurationMs) outputPath = outputPath.replace(/\.mp4$/, '_preview.mp4');
+      jobs.push({ label: 'full', viewport, outputPath });
+    }
+    for (const clip of selectedShorts) {
+      const shortTarget = shortClipToRenderTarget({
+        clip,
+        episodeSlug: slug,
+        outputRoot: flags.outputRoot,
+        timing: initialPlan.timing,
+        fullTimeline: initialPlan.fullEpisode.timeline,
+      });
+      jobs.push({
+        label: `short:${clip.id}`,
+        shortId: clip.id,
+        viewport: {
+          width: SHORTS_VIEWPORT.width,
+          height: SHORTS_VIEWPORT.height,
+          deviceScaleFactor: SHORTS_VIEWPORT.deviceScaleFactor,
+        },
+        outputPath: path.resolve(repoRoot, shortTarget.outputPath),
+      });
     }
 
-    await composeMp4({
-      frameDir: capture.frameDir,
-      frameRate: capture.frameRate,
-      outputPath,
-      ffmpegPath,
-    });
+    const captures: Array<{ job: CaptureJob; segmentTimings: Record<number, number>; durationMs: number; frameCount: number }> = [];
+    for (const job of jobs) {
+      // Sanitize job.label for use as a Windows directory name —
+      // `short:opera_game_setup` breaks mkdir because `:` is reserved.
+      const safeLabel = job.label.replace(/[:/\\?*"<>|]/g, '_');
+      const frameDir = path.resolve(
+        repoRoot,
+        '.tmp',
+        'export-frames',
+        `${slug}-${safeLabel}-${Date.now().toString(36)}`,
+      );
+      frameDirs.push(frameDir);
+      console.log(`[export] capturing ${job.label} (${job.viewport.width}x${job.viewport.height})`);
+      const capture = await recordBroadcastPlayback(browser, {
+        serverUrl: server.url,
+        episodeId: input.episodeId,
+        rawPgn: input.episodeId ? undefined : input.pgnText,
+        shortId: job.shortId,
+        frameDir,
+        viewport: job.viewport,
+        fastMode: flags.fastMode,
+        previewDurationMs: flags.previewDurationMs ?? undefined,
+      });
 
-    // Sidecar manifests.
+      await composeMp4({
+        frameDir: capture.frameDir,
+        frameRate: capture.frameRate,
+        outputPath: job.outputPath,
+        ffmpegPath,
+      });
+      captures.push({
+        job,
+        segmentTimings: capture.segmentTimings,
+        durationMs: capture.durationMs,
+        frameCount: capture.frameCount,
+      });
+      console.log(`[export] wrote ${path.relative(repoRoot, job.outputPath)}`);
+    }
+
+    // Use the FULL capture's timings (if present) for retiming. Short
+    // captures only cover a slice of the game and would produce a
+    // partial offsets map.
+    const retimeSource = captures.find((c) => c.job.label === 'full');
+    const retimedPlan = retimeSource
+      ? retimeRenderPlanWithSegmentTimings(initialPlan, retimeSource.segmentTimings)
+      : initialPlan;
+
     await writeFile(
       path.join(outDir, 'render-plan.json'),
       `${JSON.stringify(retimedPlan, null, 2)}\n`,
@@ -202,16 +325,17 @@ async function main(): Promise<void> {
           title: input.title,
           episodeId: input.episodeId,
           createdAt,
-          outputPath: path.relative(repoRoot, outputPath),
           fastMode: flags.fastMode,
           previewDurationMs: flags.previewDurationMs,
-          capture: {
-            frameCount: capture.frameCount,
-            frameRate: capture.frameRate,
-            durationMs: capture.durationMs,
-            segmentTimingsCount: Object.keys(capture.segmentTimings).length,
-          },
-          consoleEntries: capture.consoleEntries.slice(-30),
+          captures: captures.map((c) => ({
+            label: c.job.label,
+            shortId: c.job.shortId,
+            outputPath: path.relative(repoRoot, c.job.outputPath),
+            viewport: c.job.viewport,
+            frameCount: c.frameCount,
+            durationMs: c.durationMs,
+            segmentTimingsCount: Object.keys(c.segmentTimings).length,
+          })),
         },
         null,
         2,
@@ -219,14 +343,13 @@ async function main(): Promise<void> {
       'utf8',
     );
 
-    console.log(`[export] wrote ${path.relative(repoRoot, outputPath)}`);
     console.log(`[export] wrote ${path.relative(repoRoot, path.join(outDir, 'render-plan.json'))}`);
     console.log(`[export] wrote ${path.relative(repoRoot, path.join(outDir, 'render-manifest.json'))}`);
   } finally {
     await Promise.allSettled([
       browser?.close(),
       server?.stop(),
-      cleanupFrames(frameDir, flags.keepFrames),
+      ...frameDirs.map((dir) => cleanupFrames(dir, flags.keepFrames)),
     ]);
   }
 }

--- a/scripts/lib/export/browserCapture.ts
+++ b/scripts/lib/export/browserCapture.ts
@@ -27,6 +27,12 @@ export interface CaptureOptions {
   episodeId?: string;
   /** Inline PGN passed as ?pgn=<encoded>. Mutually exclusive with episodeId. */
   rawPgn?: string;
+  /**
+   * Authored short clip id, passed as ?shortId=<id>. BroadcastView
+   * uses it to slice the replay to the short's ply range and
+   * markEnded once the short's last ply has been played.
+   */
+  shortId?: string;
   /** Output frame dir (absolute path). Will be created. */
   frameDir: string;
   /** Viewport for the capture. */
@@ -157,6 +163,7 @@ function buildUrl(options: CaptureOptions): string {
   url.searchParams.set('broadcast', '1');
   if (options.episodeId) url.searchParams.set('episode', options.episodeId);
   if (options.rawPgn) url.searchParams.set('pgn', options.rawPgn);
+  if (options.shortId) url.searchParams.set('shortId', options.shortId);
   url.searchParams.set('w', String(options.viewport.width));
   url.searchParams.set('h', String(options.viewport.height));
   return url.toString();

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -38,6 +38,11 @@ export function BroadcastView() {
   const [loadError] = useState<string | null>(() => resolvePgnSource(config).error);
   const [historicalContext] = useState<string | undefined>(() => resolvePgnSource(config).historicalContext);
   const [episodeCommentatorModel] = useState<string | null>(() => resolvePgnSource(config).commentatorModel);
+  // Phase 4: resolve a short's ply range when ?shortId= is set. null
+  // means "play the full game" (full-episode capture).
+  const [shortRange] = useState<{ startPly: number; endPly: number; clipId: string } | null>(
+    () => resolvePgnSource(config).shortRange,
+  );
 
   const startedRef = useRef(false);
   const commentatorAppliedRef = useRef(false);
@@ -108,7 +113,7 @@ export function BroadcastView() {
         startReplay(pgnText, {
           historicalContext,
           moveDelayMs: 0,
-          startFromPly: 0,
+          startFromPly: shortRange?.startPly ?? 0,
         });
       },
       reset: () => {
@@ -124,7 +129,7 @@ export function BroadcastView() {
         if (replayMode) stopReplay();
       },
     });
-  }, [pgnText, historicalContext, startReplay, stopReplay, replayMode]);
+  }, [pgnText, historicalContext, startReplay, stopReplay, replayMode, shortRange?.startPly]);
 
   useEffect(() => {
     exportBridge.__markReplayReady(Boolean(pgnText) && !loadError);
@@ -147,16 +152,24 @@ export function BroadcastView() {
     return () => cancelAnimationFrame(id);
   }, []);
 
-  // End flag: replay reaches a terminal status. GameStatus is a
-  // discriminated union — every value except 'created' and
-  // 'in_progress' is terminal.
+  // End flag: replay reaches a terminal status, OR a short capture's
+  // end ply has been replayed. GameStatus is a discriminated union —
+  // every value except 'created' and 'in_progress' is terminal.
   useEffect(() => {
     if (!activeGameState) return;
     const status = activeGameState.status;
     if (status !== 'created' && status !== 'in_progress') {
       exportBridge.__markEnded();
+      return;
     }
-  }, [activeGameState]);
+    if (shortRange && activeGameState.moveHistory.length >= shortRange.endPly + 1) {
+      // The replay store's stopReplay() flips the runtime out of
+      // replayMode; the activeGameState's status stays 'in_progress'
+      // momentarily so we set ended explicitly here.
+      exportBridge.__markEnded();
+      stopReplay();
+    }
+  }, [activeGameState, shortRange, stopReplay]);
 
   if (loadError) {
     return (
@@ -204,12 +217,14 @@ interface ResolvedPgnSource {
   error: string | null;
   historicalContext: string | undefined;
   commentatorModel: string | null;
+  /** When ?shortId= matches an authored clip, its ply range. Else null. */
+  shortRange: { startPly: number; endPly: number; clipId: string } | null;
 }
 
 /**
- * Resolve a BroadcastConfig to a PGN source, historical context, and
- * episode commentator model. Pure / synchronous so it can run inside
- * a useState initializer.
+ * Resolve a BroadcastConfig to a PGN source, historical context,
+ * commentator model, and (Phase 4) authored-short ply range. Pure /
+ * synchronous so it can run inside a useState initializer.
  */
 function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): ResolvedPgnSource {
   if (config.rawPgn) {
@@ -218,6 +233,7 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
       error: null,
       historicalContext: undefined,
       commentatorModel: null,
+      shortRange: null,
     };
   }
   const episodeId = config.episodeId ?? DEFAULT_EPISODE_ID;
@@ -227,6 +243,7 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
       error: 'No episode id supplied and no default episode is registered.',
       historicalContext: undefined,
       commentatorModel: null,
+      shortRange: null,
     };
   }
   const episode = getEpisode(episodeId);
@@ -236,6 +253,27 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
       error: `Unknown episode id "${episodeId}". Check src/episodes/registry.ts.`,
       historicalContext: undefined,
       commentatorModel: null,
+      shortRange: null,
+    };
+  }
+  let shortRange: ResolvedPgnSource['shortRange'] = null;
+  if (config.shortId) {
+    const clip = episode.exports?.shorts.find((s) => s.id === config.shortId);
+    if (!clip) {
+      return {
+        pgnText: episode.pgn,
+        error: `Unknown shortId "${config.shortId}" for episode "${episode.id}". Available: ${
+          episode.exports?.shorts.map((s) => s.id).join(', ') ?? '(none)'
+        }`,
+        historicalContext: episode.historicalContext,
+        commentatorModel: episode.commentator.model,
+        shortRange: null,
+      };
+    }
+    shortRange = {
+      startPly: Math.max(0, (clip.startMoveNumber - 1) * 2),
+      endPly: Math.max(0, clip.endMoveNumber * 2 - 1),
+      clipId: clip.id,
     };
   }
   return {
@@ -243,5 +281,6 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
     error: null,
     historicalContext: episode.historicalContext,
     commentatorModel: episode.commentator.model,
+    shortRange,
   };
 }

--- a/src/production/clipManifest.ts
+++ b/src/production/clipManifest.ts
@@ -1,0 +1,115 @@
+/**
+ * Clip manifest — episode-authored "shorts" lifted into the render
+ * plan vocabulary.
+ *
+ * Phase 4 ships authored-shorts only: each episode's
+ * `exports.shorts` array of `EpisodeShortClip` is converted into
+ * `RenderTarget`s the capture pipeline can drive. Auto-detection
+ * from Stockfish eval swings is a Phase 4.1 follow-up — the
+ * detection produces the same `EpisodeShortClip` shape, so the
+ * plumbing here is shared.
+ */
+
+import type { EpisodeShortClip } from '../episodes/types';
+import {
+  estimateCommentaryDuration,
+  type NarrationTiming,
+  type RenderTarget,
+  type TimelineItem,
+  type Viewport,
+} from './renderPlan';
+
+/**
+ * Vertical 9:16 viewport for Shorts. Mobile-first consumption.
+ * The capture pipeline opens a separate browser context at this
+ * viewport, so the SPA layout is exercised at portrait dimensions.
+ */
+export const SHORTS_VIEWPORT: Viewport = {
+  width: 1080,
+  height: 1920,
+  aspectRatio: '9:16',
+  deviceScaleFactor: 1,
+};
+
+export interface ShortRenderInput {
+  /** Authored clip. Either from Episode.exports.shorts or a detection pass. */
+  clip: EpisodeShortClip;
+  /** Episode slug used for path generation. */
+  episodeSlug: string;
+  /** Output root directory (default 'exports'). */
+  outputRoot: string;
+  /** Timing knobs (matches the full-episode plan). */
+  timing: NarrationTiming;
+  /**
+   * Per-move commentary text indexed by 0-indexed ply. Optional —
+   * when absent, commentary duration falls back to the floor.
+   */
+  commentaryByMoveIndex?: Record<number, string>;
+  /** Full timeline of the source game, used to slice ply ranges. */
+  fullTimeline: TimelineItem[];
+}
+
+/**
+ * Convert an authored EpisodeShortClip into a RenderTarget.
+ *
+ * Ply mapping convention: `startMoveNumber` and `endMoveNumber` are
+ * 1-indexed full-move numbers (white + black = 1 full move). A short
+ * covering moves 8–12 captures plies 14 (white's 8th move) through
+ * 23 (black's 12th move).
+ *
+ *   startPly = (startMoveNumber - 1) * 2
+ *   endPly   = endMoveNumber * 2 - 1     # inclusive
+ */
+export function shortClipToRenderTarget(input: ShortRenderInput): RenderTarget {
+  const startPly = Math.max(0, (input.clip.startMoveNumber - 1) * 2);
+  const endPly = Math.max(startPly, input.clip.endMoveNumber * 2 - 1);
+
+  // Walk the full timeline and grab items whose moveIndex falls in
+  // [startPly, endPly]. 'gap' items are kept when they sit between
+  // an included move and its commentary; orphan gaps are dropped.
+  const sliced: TimelineItem[] = [];
+  let cursor = 0;
+  let index = 0;
+  for (const item of input.fullTimeline) {
+    const include =
+      item.moveIndex !== undefined
+        ? item.moveIndex >= startPly && item.moveIndex <= endPly
+        : sliced.length > 0 && sliced[sliced.length - 1].moveIndex !== undefined;
+    if (!include) continue;
+    const reindexed: TimelineItem = {
+      ...item,
+      index: index++,
+      startMs: cursor,
+    };
+    if (item.kind === 'commentary') {
+      reindexed.durationMs = estimateCommentaryDuration(item.text ?? '', input.timing);
+    }
+    sliced.push(reindexed);
+    cursor += reindexed.durationMs;
+  }
+
+  const lastItem = sliced[sliced.length - 1];
+  const endMs = lastItem ? lastItem.startMs + lastItem.durationMs : 0;
+  const fileName = `${input.episodeSlug}__${input.clip.id}.mp4`;
+  return {
+    id: `${input.episodeSlug}:${input.clip.id}`,
+    kind: 'short',
+    viewport: SHORTS_VIEWPORT,
+    range: {
+      startMs: 0,
+      endMs,
+      endSegmentIndex: lastItem?.index ?? 0,
+    },
+    timeline: sliced,
+    artifact: {
+      fileName,
+      durationMs: endMs,
+    },
+    outputPath: joinPath(input.outputRoot, input.episodeSlug, 'shorts', fileName),
+    shortId: input.clip.id,
+  };
+}
+
+function joinPath(...parts: string[]): string {
+  return parts.filter(Boolean).join('/');
+}

--- a/src/production/renderPlan.ts
+++ b/src/production/renderPlan.ts
@@ -247,10 +247,20 @@ export function createRenderPlanFromPgn(options: CreateRenderPlanOptions): Rende
   };
 }
 
-function estimateCommentaryDurationMs(text: string, timing: NarrationTiming): number {
+/**
+ * Planned commentary duration for a text block. Used by the initial
+ * plan builder and by clip-manifest slicing. Floors at textMinMs so
+ * empty / pre-generation slots still pace; caps at textMaxMs so a
+ * runaway commentary block doesn't dominate the timeline.
+ */
+export function estimateCommentaryDuration(text: string, timing: NarrationTiming): number {
   if (!text) return timing.textMinMs;
   const estimated = text.length * timing.textMsPerChar;
   return Math.min(timing.textMaxMs, Math.max(timing.textMinMs, estimated));
+}
+
+function estimateCommentaryDurationMs(text: string, timing: NarrationTiming): number {
+  return estimateCommentaryDuration(text, timing);
 }
 
 // ─── Retiming from measured offsets ─────────────────────────────────


### PR DESCRIPTION
## Summary

Fourth slice of the MP4 game-review export pipeline (#37). Stacks on #40.

Adds authored-shorts plumbing: each episode's `exports.shorts` array of `EpisodeShortClip` is captured as its own vertical 9:16 MP4 with the replay sliced to the clip's ply range.

### Smoke test

```
$ npm run export:game -- --episode opera_game_morphy_1858 \
    --short=opera_game_setup --fast --preview=8
[export] shorts mode: opera_game_setup
[export] capturing short:opera_game_setup (1080x1920)
[capture] opening http://127.0.0.1:5173/?...&shortId=opera_game_setup&w=1080&h=1920
[capture] captured 219 frames in 7.3 s
[ffmpeg] composing .../shorts/opera_game_morphy_1858__opera_game_setup.mp4
```

118 KB playable 9:16 MP4 in ~25 s wall clock.

### What this adds

- **`src/production/clipManifest.ts`**
  - `SHORTS_VIEWPORT` (1080×1920) constant
  - `shortClipToRenderTarget(input)` — converts an `EpisodeShortClip` into a `RenderTarget` by slicing the full-episode timeline to `[(startMoveNumber-1)*2, endMoveNumber*2-1]` plies. Reindexes the sliced timeline so segment indices start at 0.
- **`src/production/renderPlan.ts`** — exposes `estimateCommentaryDuration()` so the clip slicer re-estimates durations consistently with the full plan.
- **`src/components/BroadcastView.tsx`**
  - `resolvePgnSource()` honors `?shortId=<id>` against the episode's authored shorts and returns the ply range
  - On bridge `start()`, the resolved short's `startPly` is passed to `startReplay` (fast-forwards the chess state to the clip's first move)
  - Terminal-status effect flips `ended=true` once `moveHistory.length` crosses the short's `endPly`, triggering `stopReplay()`
- **`scripts/export-chess-mp4.ts`**
  - `--all-shorts` captures every authored short (skips full)
  - `--short=<id1,id2>` / `--shorts=<id>` captures named clips (skips full)
  - Default unchanged: full only
  - `selectShorts()` validates clip ids; throws on unknown ids
  - `jobs[]` orchestrator captures full + each selected short sequentially
  - Per-job frame dirs sanitized for Windows (no colons)
  - `render-manifest.json` now carries an array of captures with per-job metadata
- **`scripts/lib/export/browserCapture.ts`** — `CaptureOptions.shortId` field; `buildUrl` forwards it as `?shortId=<id>`

### Output layout for shorts

```
exports/<slug>/shorts/<slug>__<clipId>.mp4
```

### Known limitations (follow-ups)

- **Sequential capture only.** Clio parallelizes full + shorts; chess captures are short enough that serial is acceptable for now.
- **Commentary preamble.** The first sentence of a sliced clip may still describe earlier-game context (the commentator was prompted with the full game). A Phase 4.1 can re-prompt with a "this is a clip starting at move N" preamble.
- **Intro / outro title cards** from `EpisodeShortClip.hook` / `.payoff` are NOT rendered yet — they need a Stagehand-style `scene.title` primitive on the LLM-Chess side. Tracking as future work.
- **Auto-detection** from Stockfish eval swings is Phase 4.1. The authored-shorts plumbing here is the same code path detection will feed.

### Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean on all 5 changed files
- [x] `npm run export:game -- --episode opera_game_morphy_1858 --short=opera_game_setup --fast --preview=8` → 118 KB 9:16 MP4 in ~25 s
- [ ] Manual: `npm run export:game -- --episode opera_game_morphy_1858 --all-shorts` produces both authored shorts under `exports/opera_game_morphy_1858/shorts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
