### PR TITLE
feat(mp4-export): TTS narration recorded into MP4 (Phase 3.1)

### DIFF
--- a/scripts/export-chess-mp4.ts
+++ b/scripts/export-chess-mp4.ts
@@ -10,15 +10,23 @@
  *   npm run export:game -- --episode <id> --preview=30
  *   npm run export:game -- --episode <id> --keep-frames
  *
+ * TTS narration in the final MP4 (Phase 3.1):
+ *   Set one of:
+ *     CHESS_TTS_PROVIDER=openai    CHESS_OPENAI_API_KEY=sk-...     CHESS_TTS_VOICE=nova
+ *     CHESS_TTS_PROVIDER=qwen-cloud CHESS_QWEN_API_KEY=...          CHESS_TTS_VOICE=Chelsie
+ *     CHESS_TTS_PROVIDER=local                                      CHESS_TTS_PORT=9877
+ *   Provider, key, and voice are forwarded into the SPA's localStorage
+ *   before boot so the broadcast replay uses TTS and paces moves at
+ *   narration speed. The capture also records the narration via
+ *   MediaRecorder and ffmpeg-muxes it into the final MP4 as AAC.
+ *
+ *   With no TTS env vars set, the MP4 is silent and the replay
+ *   speedruns to checkmate in seconds.
+ *
  * Output:
  *   exports/<slug>/<slug>.mp4
  *   exports/<slug>/render-plan.json      (retimed with measured offsets)
  *   exports/<slug>/render-manifest.json  (frame count, durations, console errors)
- *
- * Phase 3 produces a SILENT mp4. Audio mux lands as a Phase 3.1
- * follow-up — the SPA plays TTS live during capture, but CDP
- * screencast does not capture audio. The render-plan.json + segment
- * timings preserve everything the audio composition step needs.
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
@@ -37,12 +45,57 @@ import {
   cleanupFrames,
   launchBrowser,
   recordBroadcastPlayback,
+  type TtsExportConfig,
 } from './lib/export/browserCapture';
 import { startViteServer } from './lib/export/devServer';
 import { composeMp4 } from './lib/export/ffmpegCompose';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '..');
+
+/**
+ * Resolve TTS config from environment variables. Returns null when
+ * no TTS env var is set (capture produces a silent MP4 and speedruns
+ * the replay since no narration gate is active).
+ *
+ *   CHESS_TTS_PROVIDER=openai|qwen-cloud|local
+ *   CHESS_TTS_VOICE=<provider-specific>
+ *   CHESS_TTS_VOLUME=0..1
+ *   CHESS_OPENAI_API_KEY=sk-...
+ *   CHESS_QWEN_API_KEY=...
+ *   CHESS_TTS_PORT=9877       (local provider only)
+ */
+function resolveTtsConfigFromEnv(): TtsExportConfig | null {
+  const provider = process.env.CHESS_TTS_PROVIDER as TtsExportConfig['provider'] | undefined;
+  if (!provider) return null;
+  if (provider !== 'openai' && provider !== 'qwen-cloud' && provider !== 'local') {
+    throw new Error(
+      `CHESS_TTS_PROVIDER must be one of: openai, qwen-cloud, local (got: "${provider}")`,
+    );
+  }
+  const apiKey =
+    provider === 'openai'
+      ? process.env.CHESS_OPENAI_API_KEY
+      : provider === 'qwen-cloud'
+        ? process.env.CHESS_QWEN_API_KEY
+        : undefined;
+  if (provider !== 'local' && !apiKey) {
+    throw new Error(
+      `CHESS_TTS_PROVIDER=${provider} requires ${
+        provider === 'openai' ? 'CHESS_OPENAI_API_KEY' : 'CHESS_QWEN_API_KEY'
+      } to be set.`,
+    );
+  }
+  const volume = process.env.CHESS_TTS_VOLUME ? Number(process.env.CHESS_TTS_VOLUME) : undefined;
+  const port = process.env.CHESS_TTS_PORT ? Number(process.env.CHESS_TTS_PORT) : undefined;
+  return {
+    provider,
+    apiKey,
+    voice: process.env.CHESS_TTS_VOICE,
+    volume: volume && Number.isFinite(volume) ? volume : undefined,
+    port: port && Number.isFinite(port) ? port : undefined,
+  };
+}
 
 interface CliFlags {
   pgnPath: string | null;
@@ -220,6 +273,21 @@ async function main(): Promise<void> {
   if (skipFull) console.log(`[export]   shorts mode: ${selectedShorts.map((s) => s.id).join(', ')}`);
   else if (input.authoredShorts.length > 0) console.log(`[export]   ${input.authoredShorts.length} authored short(s) available (skipped; pass --all-shorts to include)`);
 
+  // Phase 3.1: resolve TTS config from env. Without TTS the capture
+  // produces a silent MP4 and the replay speedruns (no narration gate
+  // to pace move advancement). With TTS, narration is recorded via
+  // MediaRecorder in the SPA and muxed into the MP4 here.
+  const ttsConfig = resolveTtsConfigFromEnv();
+  if (ttsConfig) {
+    console.log(
+      `[export]   TTS: ${ttsConfig.provider}${ttsConfig.voice ? ` voice=${ttsConfig.voice}` : ''}`,
+    );
+  } else {
+    console.log(
+      '[export]   TTS: disabled (set CHESS_TTS_PROVIDER + key to enable; otherwise replay speedruns and MP4 is silent)',
+    );
+  }
+
   let server: Awaited<ReturnType<typeof startViteServer>> | undefined;
   let browser: Awaited<ReturnType<typeof launchBrowser>> | undefined;
   const frameDirs: string[] = [];
@@ -265,7 +333,13 @@ async function main(): Promise<void> {
       });
     }
 
-    const captures: Array<{ job: CaptureJob; segmentTimings: Record<number, number>; durationMs: number; frameCount: number }> = [];
+    const captures: Array<{
+      job: CaptureJob;
+      segmentTimings: Record<number, number>;
+      durationMs: number;
+      frameCount: number;
+      audioBytes: number;
+    }> = [];
     for (const job of jobs) {
       // Sanitize job.label for use as a Windows directory name —
       // `short:opera_game_setup` breaks mkdir because `:` is reserved.
@@ -287,19 +361,34 @@ async function main(): Promise<void> {
         viewport: job.viewport,
         fastMode: flags.fastMode,
         previewDurationMs: flags.previewDurationMs ?? undefined,
+        ttsConfig: ttsConfig ?? undefined,
       });
+
+      // Write recorded narration audio to the per-job frame dir so it's
+      // cleaned up alongside the frames. ffmpeg reads it as a second
+      // input and re-encodes to AAC. Skip when nothing was recorded.
+      let audioPath: string | undefined;
+      let audioBytes = 0;
+      if (capture.recordedAudioBase64) {
+        const audioBuffer = Buffer.from(capture.recordedAudioBase64, 'base64');
+        audioBytes = audioBuffer.length;
+        audioPath = path.join(frameDir, 'narration.webm');
+        await writeFile(audioPath, audioBuffer);
+      }
 
       await composeMp4({
         frameDir: capture.frameDir,
         frameRate: capture.frameRate,
         outputPath: job.outputPath,
         ffmpegPath,
+        audioPath,
       });
       captures.push({
         job,
         segmentTimings: capture.segmentTimings,
         durationMs: capture.durationMs,
         frameCount: capture.frameCount,
+        audioBytes,
       });
       console.log(`[export] wrote ${path.relative(repoRoot, job.outputPath)}`);
     }
@@ -327,6 +416,7 @@ async function main(): Promise<void> {
           createdAt,
           fastMode: flags.fastMode,
           previewDurationMs: flags.previewDurationMs,
+          ttsProvider: ttsConfig?.provider ?? null,
           captures: captures.map((c) => ({
             label: c.job.label,
             shortId: c.job.shortId,
@@ -335,6 +425,7 @@ async function main(): Promise<void> {
             frameCount: c.frameCount,
             durationMs: c.durationMs,
             segmentTimingsCount: Object.keys(c.segmentTimings).length,
+            audioBytes: c.audioBytes,
           })),
         },
         null,

--- a/scripts/lib/export/browserCapture.ts
+++ b/scripts/lib/export/browserCapture.ts
@@ -49,6 +49,25 @@ export interface CaptureOptions {
    * Defaults to plannedDurationMs * 1.5 + 5 minutes if not set.
    */
   endTimeoutMs?: number;
+  /**
+   * Optional TTS config to seed into the SPA's localStorage before
+   * the page boots. When set, the SPA's broadcast mode uses TTS and
+   * narration paces the replay; recorded narration is muxed into the
+   * MP4 via AudioNarrationQueue's MediaRecorder tap.
+   */
+  ttsConfig?: TtsExportConfig;
+}
+
+export interface TtsExportConfig {
+  provider: 'openai' | 'qwen-cloud' | 'local';
+  /** Required for cloud providers; ignored for local. */
+  apiKey?: string;
+  /** Provider-specific voice id (e.g. 'nova' for OpenAI, 'Chelsie' for Qwen). */
+  voice?: string;
+  /** Volume 0..1. Default 0.8. */
+  volume?: number;
+  /** Local sidecar port. Default 9877. Only used when provider === 'local'. */
+  port?: number;
 }
 
 export interface CaptureResult {
@@ -61,6 +80,12 @@ export interface CaptureResult {
   segmentTimings: Record<number, number>;
   /** Browser console errors / warnings collected during the run. */
   consoleEntries: BrowserConsoleEntry[];
+  /**
+   * Base64-encoded webm/opus narration audio recorded via MediaRecorder
+   * tap on the AudioNarrationQueue. Empty string when TTS was disabled
+   * or no narration played.
+   */
+  recordedAudioBase64: string;
 }
 
 export interface BrowserConsoleEntry {
@@ -76,6 +101,16 @@ export async function recordBroadcastPlayback(browser: Browser, options: Capture
     colorScheme: 'dark',
     reducedMotion: 'no-preference',
   });
+  // Seed TTS settings into localStorage BEFORE any SPA module loads
+  // so zustand's persist middleware picks them up on boot. The page
+  // is started fresh by Playwright, so localStorage is empty — without
+  // this seeding, ttsEnabled defaults to false and the replay
+  // speedruns to checkmate in milliseconds (no narration gate to
+  // pace it).
+  if (options.ttsConfig) {
+    await context.addInitScript(seedTtsSettingsScript(options.ttsConfig));
+  }
+
   const page = await context.newPage();
   const consoleEntries: BrowserConsoleEntry[] = [];
   page.on('console', (message) => {
@@ -127,16 +162,31 @@ export async function recordBroadcastPlayback(browser: Browser, options: Capture
     const durationMs = Math.max(1000, endedAtMs - startedAtMs);
     const frameCount = await frameWriter.finalize(durationMs);
 
-    // Read segment timings + render plan diagnostic back out.
-    const segmentTimings =
-      (await page
-        .evaluate(() => window.__CHESS_EXPORT__?.state().segmentTimings ?? {})
-        .catch(() => ({}))) ?? {};
+    // Read segment timings + recorded audio back out. The bridge
+    // populates segmentTimings as commentary plays, and stores the
+    // base64-encoded webm audio after BroadcastView's end-of-replay
+    // effect calls finalizeRecording().
+    const bridgeReadback = (await page
+      .evaluate(() => {
+        const s = window.__CHESS_EXPORT__?.state();
+        return {
+          segmentTimings: s?.segmentTimings ?? {},
+          recordedAudio: s?.recordedAudio ?? '',
+        };
+      })
+      .catch(() => ({ segmentTimings: {}, recordedAudio: '' }))) ?? {
+      segmentTimings: {},
+      recordedAudio: '',
+    };
+    const segmentTimings = bridgeReadback.segmentTimings;
+    const recordedAudioBase64 = bridgeReadback.recordedAudio;
 
     console.log(
       `[capture] captured ${frameCount} frames in ${(durationMs / 1000).toFixed(1)} s, ${
         Object.keys(segmentTimings).length
-      } segment timings`,
+      } segment timings, ${
+        recordedAudioBase64 ? `${Math.round((recordedAudioBase64.length * 3) / 4 / 1024)} KB audio` : 'no audio'
+      }`,
     );
     if (Object.keys(segmentTimings).length === 0) {
       console.warn(
@@ -151,10 +201,68 @@ export async function recordBroadcastPlayback(browser: Browser, options: Capture
       durationMs,
       segmentTimings,
       consoleEntries,
+      recordedAudioBase64,
     };
   } finally {
     await context.close().catch(() => undefined);
   }
+}
+
+/**
+ * Serialize a TTS export config into a stringified init script that
+ * pre-seeds the SPA's zustand persist record before any module loads.
+ *
+ * Zustand persist stores state under `<persist.name>` (here:
+ * `llm-chess-settings`) as a JSON envelope `{ state: {...}, version }`.
+ * We only need to set the TTS-specific fields and an `ttsEnabled: true`
+ * flag; the rest of the settings fall back to their schema defaults
+ * via the migrate function on first hydrate.
+ */
+function seedTtsSettingsScript(tts: TtsExportConfig): string {
+  const payload = {
+    state: {
+      ttsEnabled: true,
+      ttsProvider: tts.provider,
+      ttsCloudApiKey: tts.apiKey ?? '',
+      ttsCloudVoice: tts.voice ?? (tts.provider === 'openai' ? 'nova' : 'Chelsie'),
+      ttsVoice: tts.voice ?? 'default',
+      ttsVolume: tts.volume ?? 0.8,
+      ttsPort: tts.port ?? 9877,
+    },
+    version: 8,
+  };
+  // The init script runs in the page's main world before any module
+  // executes. It merges into any existing persisted state so other
+  // settings (provider key, model preferences) survive across calls
+  // — though in headless Chromium with a fresh profile there's
+  // nothing to merge.
+  return `
+    (function () {
+      try {
+        const KEY = 'llm-chess-settings';
+        const incoming = ${JSON.stringify(payload)};
+        const raw = localStorage.getItem(KEY);
+        if (raw) {
+          try {
+            const existing = JSON.parse(raw);
+            const merged = {
+              state: { ...(existing.state || {}), ...incoming.state },
+              version: incoming.version,
+            };
+            localStorage.setItem(KEY, JSON.stringify(merged));
+          } catch (_e) {
+            localStorage.setItem(KEY, JSON.stringify(incoming));
+          }
+        } else {
+          localStorage.setItem(KEY, JSON.stringify(incoming));
+        }
+      } catch (_e) {
+        // localStorage may be unavailable (private mode, etc.); the
+        // SPA falls back to its schema defaults (TTS off) and the
+        // capture pipeline will warn about no audio.
+      }
+    })();
+  `;
 }
 
 function buildUrl(options: CaptureOptions): string {
@@ -251,6 +359,7 @@ declare global {
         ended: boolean;
         segmentTimings: Record<number, number>;
         renderPlan?: unknown;
+        recordedAudio: string;
       };
     };
   }

--- a/scripts/lib/export/ffmpegCompose.ts
+++ b/scripts/lib/export/ffmpegCompose.ts
@@ -1,12 +1,12 @@
 /**
  * Compose a frame sequence + (optional) narration audio into an MP4
- * via ffmpeg-static. No audio mixing in Phase 3 — the SPA plays TTS
- * live during capture but the audio is NOT recorded by CDP screencast;
- * we emit a silent MP4 for now. A follow-up can add pre-rendered
- * TTS clips composed at segmentTimings offsets (Clio's pattern).
+ * via ffmpeg-static.
  *
- * Silent-MP4-first keeps Phase 3 reviewable. Audio mux lands as a
- * Phase 3.1 follow-up after Phase 3 merges.
+ * Phase 3 shipped silent MP4s; Phase 3.1 adds audio mux. The SPA's
+ * AudioNarrationQueue taps a MediaRecorder onto its gain node in
+ * broadcast mode, base64-encodes the result onto the export bridge,
+ * and the orchestrator writes that webm/opus blob to disk before
+ * calling here. ffmpeg re-encodes to AAC for MP4 compatibility.
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
@@ -23,6 +23,13 @@ export interface ComposeOptions {
   outputPath: string;
   /** Absolute path to the ffmpeg binary. */
   ffmpegPath: string;
+  /**
+   * Optional path to an audio file (webm/opus from MediaRecorder, or
+   * any ffmpeg-decodable container) to mux into the MP4. When set,
+   * the audio is re-encoded to AAC and the output uses `-shortest` so
+   * the MP4 ends with whichever stream finishes first.
+   */
+  audioPath?: string;
 }
 
 /**
@@ -40,12 +47,14 @@ export interface ComposeOptions {
  */
 export async function composeMp4(options: ComposeOptions): Promise<void> {
   await mkdir(path.dirname(options.outputPath), { recursive: true });
+  const hasAudio = Boolean(options.audioPath);
   const args = [
     '-y',
     '-framerate',
     String(options.frameRate),
     '-i',
     path.join(options.frameDir, 'frame_%08d.jpg'),
+    ...(hasAudio ? ['-i', options.audioPath as string] : []),
     '-c:v',
     'libx264',
     '-pix_fmt',
@@ -56,9 +65,27 @@ export async function composeMp4(options: ComposeOptions): Promise<void> {
     'veryfast',
     '-crf',
     '20',
+    ...(hasAudio
+      ? [
+          '-c:a',
+          'aac',
+          '-b:a',
+          '160k',
+          // Map: video from input 0, audio from input 1.
+          '-map',
+          '0:v:0',
+          '-map',
+          '1:a:0',
+          // End at the shorter of the two streams. The audio
+          // recorder starts after the video, so the audio is
+          // typically slightly shorter; without -shortest the MP4
+          // would end with a tail of silent video.
+          '-shortest',
+        ]
+      : []),
     options.outputPath,
   ];
-  console.log(`[ffmpeg] composing ${options.outputPath}`);
+  console.log(`[ffmpeg] composing ${options.outputPath}${hasAudio ? ' (with audio)' : ' (silent)'}`);
   await runFfmpeg(options.ffmpegPath, args);
 }
 

--- a/src/app/exportBridge.ts
+++ b/src/app/exportBridge.ts
@@ -47,6 +47,17 @@ export interface ExportBridgeState {
    * Optional to keep the contract backward-compatible with Phase 1.
    */
   renderPlan?: unknown;
+  /**
+   * Base64-encoded webm audio recorded by AudioNarrationQueue during
+   * broadcast playback. Populated after `ended` fires. The Phase 3.1
+   * capture pipeline decodes this, writes it to disk, and ffmpeg-muxes
+   * it onto the frame sequence to produce an MP4 with audio.
+   *
+   * Empty string while recording is in progress or if recording was
+   * never started (TTS off). The mime type is always
+   * `audio/webm;codecs=opus` (MediaRecorder default on Chromium).
+   */
+  recordedAudio: string;
 }
 
 /**
@@ -80,6 +91,8 @@ export interface ExportBridge {
   __recordSegmentTiming(moveIndex: number, offsetMs: number): void;
   /** Internal: BroadcastView attaches the render plan when start() runs. */
   __setRenderPlan(plan: unknown): void;
+  /** Internal: BroadcastView stores the final recorded audio after ended. */
+  __setRecordedAudio(base64: string): void;
   /** Internal: installExportBridge sets broadcastMode at boot. */
   __setBroadcastMode(value: boolean): void;
 }
@@ -92,6 +105,7 @@ const state: ExportBridgeState = {
   audioReady: false,
   ended: false,
   segmentTimings: {},
+  recordedAudio: '',
 };
 
 let hooks: ExportBridgeHooks | null = null;
@@ -103,6 +117,7 @@ export const exportBridge: ExportBridge = {
     state.audioReady = false;
     state.ended = false;
     state.segmentTimings = {};
+    state.recordedAudio = '';
     hooks?.reset();
   },
   start() {
@@ -138,6 +153,9 @@ export const exportBridge: ExportBridge = {
   },
   __setRenderPlan(plan) {
     state.renderPlan = plan;
+  },
+  __setRecordedAudio(base64) {
+    state.recordedAudio = base64;
   },
   __setBroadcastMode(value) {
     state.broadcastMode = value;

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -45,6 +45,7 @@ export function BroadcastView() {
   );
 
   const startedRef = useRef(false);
+  const endedRef = useRef(false);
   const commentatorAppliedRef = useRef(false);
 
   // Apply the episode's commentator model id to the replay store
@@ -104,6 +105,11 @@ export function BroadcastView() {
           audioQueue.setSegmentStartCallback((moveIndex, offsetMs) => {
             exportBridge.__recordSegmentTiming(moveIndex, offsetMs);
           });
+          // Phase 3.1: tap the queue's gain node via MediaRecorder
+          // so the capture pipeline can mux the rendered narration
+          // into the final MP4. No-op when TTS is disabled (queue
+          // never plays anything).
+          audioQueue.startRecording();
         } else {
           console.warn(
             '[BroadcastView] No active AudioNarrationQueue at start() — segment timings will not be recorded',
@@ -155,20 +161,26 @@ export function BroadcastView() {
   // End flag: replay reaches a terminal status, OR a short capture's
   // end ply has been replayed. GameStatus is a discriminated union —
   // every value except 'created' and 'in_progress' is terminal.
+  //
+  // Phase 3.1: also drain the audio queue, stop the MediaRecorder,
+  // and store the recorded narration on the bridge as base64 so the
+  // capture pipeline can mux it into the MP4.
   useEffect(() => {
     if (!activeGameState) return;
     const status = activeGameState.status;
-    if (status !== 'created' && status !== 'in_progress') {
+    const isTerminal = status !== 'created' && status !== 'in_progress';
+    const shortDone = shortRange && activeGameState.moveHistory.length >= shortRange.endPly + 1;
+    if (!isTerminal && !shortDone) return;
+
+    // Once-only: the effect re-runs on every game state change, but
+    // we want to flip ended (and stop the recorder) exactly once.
+    if (endedRef.current) return;
+    endedRef.current = true;
+
+    void finalizeRecording().finally(() => {
       exportBridge.__markEnded();
-      return;
-    }
-    if (shortRange && activeGameState.moveHistory.length >= shortRange.endPly + 1) {
-      // The replay store's stopReplay() flips the runtime out of
-      // replayMode; the activeGameState's status stays 'in_progress'
-      // momentarily so we set ended explicitly here.
-      exportBridge.__markEnded();
-      stopReplay();
-    }
+      if (shortDone && !isTerminal) stopReplay();
+    });
   }, [activeGameState, shortRange, stopReplay]);
 
   if (loadError) {
@@ -283,4 +295,43 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
     commentatorModel: episode.commentator.model,
     shortRange,
   };
+}
+
+/**
+ * Drain the audio queue, stop the MediaRecorder, base64-encode the
+ * resulting webm blob, and store it on the export bridge.
+ *
+ * The audio queue's narrationGate already waits for in-flight TTS
+ * synthesis before the runtime advances, but it doesn't wait for
+ * the FINAL clip to finish playing — so we waitUntilDone() and add
+ * a small grace window to let the last MediaRecorder chunk land
+ * before stopping. Anything else risks clipping the closing
+ * narration.
+ *
+ * No-op when TTS was disabled (audio queue's stopRecording returns
+ * null because startRecording was never called effectively).
+ */
+async function finalizeRecording(): Promise<void> {
+  const audioQueue = getActiveAudioNarrationQueue();
+  if (!audioQueue) return;
+  try {
+    await audioQueue.waitUntilDone();
+  } catch {
+    // waitUntilDone() throwing means there was nothing to drain.
+  }
+  // Grace window for the last MediaRecorder data chunk.
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const blob = await audioQueue.stopRecording();
+  if (!blob || blob.size === 0) return;
+  const arrayBuffer = await blob.arrayBuffer();
+  // Chunked encode — String.fromCharCode.apply with a large array
+  // hits the JS engine's argument count limit (262144 on V8).
+  const bytes = new Uint8Array(arrayBuffer);
+  const chunkSize = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunkSize)));
+  }
+  const base64 = btoa(binary);
+  exportBridge.__setRecordedAudio(base64);
 }

--- a/src/tts/audio-queue.ts
+++ b/src/tts/audio-queue.ts
@@ -75,6 +75,18 @@ export class AudioNarrationQueue {
   /** Tracks which moveIndex we last fired onSegmentStart for. */
   private _lastFiredSegmentMoveIndex = -1;
 
+  /**
+   * MediaStreamAudioDestinationNode that mirrors the gain node so a
+   * MediaRecorder can capture everything the queue plays. Only created
+   * when startRecording() is called (broadcast / MP4-export mode); the
+   * normal SPA path never instantiates it.
+   */
+  private mediaStreamDest: MediaStreamAudioDestinationNode | null = null;
+  /** Active MediaRecorder during a broadcast capture. */
+  private mediaRecorder: MediaRecorder | null = null;
+  /** Accumulated audio chunks. Combined into a single Blob by stopRecording(). */
+  private recordedChunks: Blob[] = [];
+
   /** Number of commentary entries waiting or being played. */
   private _entryCount = 0;
 
@@ -93,6 +105,51 @@ export class AudioNarrationQueue {
       this.gainNode.connect(this.audioContext.destination);
     }
     return this.audioContext;
+  }
+
+  /**
+   * Start recording everything the queue plays from this point until
+   * stopRecording() is called. Used by broadcast / MP4-export mode to
+   * capture narration into the final MP4.
+   *
+   * Idempotent: if already recording, no-op. Creates the context lazily
+   * if needed (AudioContext is normally lazy-created on first synth).
+   */
+  startRecording(): void {
+    if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') return;
+    const ctx = this.getContext();
+    if (!this.mediaStreamDest) {
+      this.mediaStreamDest = ctx.createMediaStreamDestination();
+      this.gainNode?.connect(this.mediaStreamDest);
+    }
+    this.recordedChunks = [];
+    // MediaRecorder default mimetype is webm/opus on Chromium — fine
+    // for ffmpeg to re-encode to AAC in the final MP4 mux.
+    this.mediaRecorder = new MediaRecorder(this.mediaStreamDest.stream);
+    this.mediaRecorder.ondataavailable = (event) => {
+      if (event.data && event.data.size > 0) this.recordedChunks.push(event.data);
+    };
+    // Pump chunks every 250 ms so a long capture doesn't sit on one
+    // monolithic Blob until stop().
+    this.mediaRecorder.start(250);
+  }
+
+  /**
+   * Stop the active recording and return the accumulated audio Blob.
+   * Resolves to null if recording was never started.
+   */
+  async stopRecording(): Promise<Blob | null> {
+    if (!this.mediaRecorder) return null;
+    const recorder = this.mediaRecorder;
+    if (recorder.state === 'inactive') return new Blob(this.recordedChunks);
+    return new Promise<Blob | null>((resolve) => {
+      recorder.onstop = () => {
+        const blob = new Blob(this.recordedChunks, { type: recorder.mimeType || 'audio/webm' });
+        this.mediaRecorder = null;
+        resolve(blob);
+      };
+      recorder.stop();
+    });
   }
 
   /**
@@ -320,8 +377,7 @@ export class AudioNarrationQueue {
     if (this.processingPromise || this.playing || this.paused || this.queue.length === 0) return;
     this.playing = true;
     const runGeneration = this.generation;
-    let runPromise: Promise<void>;
-    runPromise = this.processQueue(runGeneration).finally(() => {
+    const runPromise: Promise<void> = this.processQueue(runGeneration).finally(() => {
       if (this.processingPromise === runPromise) {
         this.processingPromise = null;
       }


### PR DESCRIPTION
## Summary

Closes the silent-MP4 limitation called out in #36. Adds real TTS narration to the exported MP4.

### What was wrong

Phase 3 shipped silent MP4s because CDP screencast only captures video, not audio. The SPA's `AudioNarrationQueue` plays narration into the browser's audio output, but nothing was tapping it. Worse, the SPA's `ttsEnabled` setting persists to localStorage which is per-profile — headless Chromium under Playwright always launches with an empty profile, so TTS was off by default and the replay speedran to checkmate in milliseconds via `moveDelayMs=0`.

### What this adds

- **`src/tts/audio-queue.ts`** — `startRecording()` taps a `MediaStreamAudioDestinationNode` onto the existing gain node and starts a `MediaRecorder` on it (webm/opus). `stopRecording()` returns the Blob. Drive-by `prefer-const` fix on the processing-promise self-ref.
- **`src/app/exportBridge.ts`** — new `recordedAudio: string` state field + internal `__setRecordedAudio(base64)` hook.
- **`src/components/BroadcastView.tsx`** — `bridge.start()` calls `audioQueue.startRecording()`. End-of-replay effect calls `finalizeRecording()`: waits for the queue to drain, gives a 250 ms grace window for the last MediaRecorder chunk, base64-encodes the blob, stores on the bridge. Only THEN does `__markEnded()` fire, so the capture pipeline reading `state.ended` is guaranteed to also see the final audio.
- **`scripts/lib/export/browserCapture.ts`** — new `CaptureOptions.ttsConfig` + `TtsExportConfig`. When set, `page.addInitScript` writes the zustand persist envelope into localStorage **before any SPA module loads**, so the store hydrates with `ttsEnabled=true` plus provider/key/voice and the replay paces itself at narration speed. `CaptureResult.recordedAudioBase64` carries the bridge's audio readback.
- **`scripts/lib/export/ffmpegCompose.ts`** — `ComposeOptions.audioPath`. When set, ffmpeg adds it as a second input, encodes to AAC at 160 kbps, maps video from input 0 + audio from input 1, and uses `-shortest` so the MP4 ends with whichever stream finishes first.
- **`scripts/export-chess-mp4.ts`** — `resolveTtsConfigFromEnv()` reads `CHESS_TTS_PROVIDER`, `CHESS_OPENAI_API_KEY` / `CHESS_QWEN_API_KEY`, `CHESS_TTS_VOICE`, `CHESS_TTS_VOLUME`, `CHESS_TTS_PORT`. Writes per-job `narration.webm` to the frame dir and passes it to ffmpeg. `render-manifest.json` records `ttsProvider` + per-job `audioBytes`.

### Usage

```cmd
set CHESS_TTS_PROVIDER=openai
set CHESS_OPENAI_API_KEY=sk-...
set CHESS_TTS_VOICE=nova
npm run export:game -- --episode opera_game_morphy_1858
```

Without those env vars the export still works — produces a silent MP4 like Phase 3 did and the replay speedruns. The console says which mode is active.

### Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — clean on all 6 changed files
- [x] Regression: silent path still produces a 174 KB MP4 with no audio track and `(silent)` in the ffmpeg log
- [x] Structural: `CHESS_TTS_PROVIDER=local` (no sidecar) triggers the seed-script path and the capture exits cleanly
- [ ] **End-to-end audio mux** — run with a real OpenAI / Qwen key set in the env vars above, confirm the MP4 has an audio track and narration is in sync with the captions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
