### PR TITLE
feat(mp4-export): load TTS config from gitignored .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# Copy this file to .env (gitignored) and fill in your credentials.
+# scripts/export-chess-mp4.ts loads .env from the repo root before
+# reading process.env, so any value here is picked up by:
+#   npm run export:game -- --episode opera_game_morphy_1858
+#
+# Without these set, the MP4 export still runs but produces a silent
+# video and the replay speedruns (no narration gate to pace it).
+#
+# An env var already set in your shell wins over .env. Quotes around
+# values are optional and are stripped.
+
+# === TTS provider for narration recorded into the MP4 ===
+
+# Pick one of: openai | qwen-cloud | local
+CHESS_TTS_PROVIDER=openai
+
+# OpenAI TTS — required when CHESS_TTS_PROVIDER=openai
+# Voices: alloy, echo, fable, onyx, nova, shimmer
+CHESS_OPENAI_API_KEY=sk-replace-me
+CHESS_TTS_VOICE=nova
+
+# Qwen3-TTS via DashScope — required when CHESS_TTS_PROVIDER=qwen-cloud
+# Voices: Chelsie, Cherry, Serena, Ethan, Aiden, River
+# CHESS_QWEN_API_KEY=sk-replace-me
+# CHESS_TTS_VOICE=Chelsie
+
+# Local Python TTS sidecar — required when CHESS_TTS_PROVIDER=local
+# Start the sidecar separately:
+#   cd src-tauri/sidecars/tts-server && python server.py --port 9877
+# CHESS_TTS_PORT=9877
+
+# Output volume 0..1; default 0.8
+# CHESS_TTS_VOLUME=0.8

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ exports/
 
 # TTS clip cache (content-hashed)
 .tts-cache/
+
+# Local secrets for the MP4 export pipeline (TTS keys, etc.)
+.env
+.env.local
+!.env.example

--- a/scripts/export-chess-mp4.ts
+++ b/scripts/export-chess-mp4.ts
@@ -11,14 +11,19 @@
  *   npm run export:game -- --episode <id> --keep-frames
  *
  * TTS narration in the final MP4 (Phase 3.1):
- *   Set one of:
- *     CHESS_TTS_PROVIDER=openai    CHESS_OPENAI_API_KEY=sk-...     CHESS_TTS_VOICE=nova
- *     CHESS_TTS_PROVIDER=qwen-cloud CHESS_QWEN_API_KEY=...          CHESS_TTS_VOICE=Chelsie
- *     CHESS_TTS_PROVIDER=local                                      CHESS_TTS_PORT=9877
- *   Provider, key, and voice are forwarded into the SPA's localStorage
- *   before boot so the broadcast replay uses TTS and paces moves at
- *   narration speed. The capture also records the narration via
- *   MediaRecorder and ffmpeg-muxes it into the final MP4 as AAC.
+ *   Configure via a gitignored `.env` at the repo root, or via env
+ *   vars in your shell — env beats .env. See `.env.example` for the
+ *   full set of supported keys. Quick start with OpenAI:
+ *
+ *     CHESS_TTS_PROVIDER=openai
+ *     CHESS_OPENAI_API_KEY=sk-...
+ *     CHESS_TTS_VOICE=nova
+ *
+ *   The provider, key, and voice are forwarded into the SPA's
+ *   localStorage before boot, so the broadcast replay uses TTS and
+ *   paces moves at narration speed. The capture also records the
+ *   narration via MediaRecorder and ffmpeg-muxes it into the final
+ *   MP4 as AAC.
  *
  *   With no TTS env vars set, the MP4 is silent and the replay
  *   speedruns to checkmate in seconds.
@@ -30,6 +35,7 @@
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ffmpegStatic from 'ffmpeg-static';
@@ -54,9 +60,42 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '..');
 
 /**
- * Resolve TTS config from environment variables. Returns null when
- * no TTS env var is set (capture produces a silent MP4 and speedruns
- * the replay since no narration gate is active).
+ * Load `.env` from the repo root into process.env. Idempotent — only
+ * keys not already set are written. Format is the standard
+ *   KEY=value
+ *   # comment
+ * dialect; values may be wrapped in single or double quotes (which
+ * are stripped). Lines without `=` are ignored. No new dependency:
+ * the file is small enough to parse by hand.
+ *
+ * .env is gitignored; .env.example is committed as a template.
+ */
+function loadDotEnv(filePath: string): void {
+  if (!existsSync(filePath)) return;
+  const raw = readFileSync(filePath, 'utf8');
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    // Strip surrounding single or double quotes; preserve inner content.
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    // Don't clobber an explicitly-set env var — env wins over .env.
+    if (process.env[key] === undefined) process.env[key] = value;
+  }
+}
+
+// Load .env once at module init, before any code reads process.env.
+loadDotEnv(path.resolve(repoRoot, '.env'));
+
+/**
+ * Resolve TTS config from environment variables (or .env). Returns
+ * null when no TTS env var is set (capture produces a silent MP4
+ * and speedruns the replay since no narration gate is active).
  *
  *   CHESS_TTS_PROVIDER=openai|qwen-cloud|local
  *   CHESS_TTS_VOICE=<provider-specific>
@@ -84,6 +123,21 @@ function resolveTtsConfigFromEnv(): TtsExportConfig | null {
       `CHESS_TTS_PROVIDER=${provider} requires ${
         provider === 'openai' ? 'CHESS_OPENAI_API_KEY' : 'CHESS_QWEN_API_KEY'
       } to be set.`,
+    );
+  }
+  // Catch obvious placeholder values before they reach the SPA. The
+  // synthesize() call rejects bad keys silently from the capture's
+  // perspective (no audio is recorded, replay speedruns), which is
+  // the worst failure mode — fail loud instead.
+  if (provider === 'openai' && apiKey && !apiKey.startsWith('sk-')) {
+    throw new Error(
+      `CHESS_OPENAI_API_KEY does not start with "sk-" (got ${apiKey.length} chars). ` +
+        'Looks like you left the .env.example placeholder in place. Paste your real OpenAI key into .env.',
+    );
+  }
+  if (provider !== 'local' && apiKey && apiKey.length < 20) {
+    throw new Error(
+      `${provider === 'openai' ? 'CHESS_OPENAI_API_KEY' : 'CHESS_QWEN_API_KEY'} is only ${apiKey.length} chars long; that's not a real API key.`,
     );
   }
   const volume = process.env.CHESS_TTS_VOLUME ? Number(process.env.CHESS_TTS_VOLUME) : undefined;


### PR DESCRIPTION
## Summary

Adds a gitignored `.env` loader so TTS credentials can stay in a file at the repo root instead of being exported into the shell every time.

Also catches obvious placeholder keys before the capture starts, because synthesize() failing silently inside the SPA was the worst failure mode — the previous behavior was "no audio, replay speedruns, no error in the logs."

### What this adds

- **`scripts/export-chess-mp4.ts`** — `loadDotEnv(filePath)`, a tiny line-by-line `.env` parser (~20 lines, no new dependency). Called once at module init against `<repoRoot>/.env`. Shell env wins on conflict. `resolveTtsConfigFromEnv()` now throws if the OpenAI key doesn't start with `sk-` or any cloud key is shorter than 20 chars.
- **`.gitignore`** — ignore `.env` and `.env.local`; allowlist `.env.example` so the template stays committed.
- **`.env.example`** — template with OpenAI / Qwen3-TTS / local-sidecar examples. Copy to `.env` and paste your actual key.

### Usage

```
cp .env.example .env
# edit .env, paste your CHESS_OPENAI_API_KEY=sk-...
npm run export:game -- --episode opera_game_morphy_1858
```

### Test plan

- [x] `npm run build` passes
- [x] Regression (no .env, no env vars): silent MP4 path unchanged
- [x] Placeholder key value `CHESS_OPENAI_API_KEY=.env.example` (caught during the first real end-to-end test) is now rejected upfront with: `CHESS_OPENAI_API_KEY does not start with "sk-" (got 12 chars). Looks like you left the .env.example placeholder in place.`
- [ ] End-to-end audio mux with a real key — pending the user pasting `sk-...` into `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Environment file support for configuring MP4 export and TTS narration settings
  * Multiple TTS provider options (OpenAI, Qwen Cloud, local Python sidecar)

* **Bug Fixes**
  * Enhanced validation for API keys to catch configuration errors early

* **Chores**
  * Updated configuration templates and gitignore for environment file management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->