### PR TITLE
feat(mp4-export): fix replay pacing, audio recording, dead-air compression

### DIFF
--- a/scripts/export-chess-mp4.ts
+++ b/scripts/export-chess-mp4.ts
@@ -55,6 +55,7 @@ import {
 } from './lib/export/browserCapture';
 import { startViteServer } from './lib/export/devServer';
 import { composeMp4 } from './lib/export/ffmpegCompose';
+import { compressDeadAir } from './lib/export/compressDeadAir';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '..');
@@ -393,6 +394,8 @@ async function main(): Promise<void> {
       durationMs: number;
       frameCount: number;
       audioBytes: number;
+      tightOutputPath?: string;
+      compressedRemovedS: number;
     }> = [];
     for (const job of jobs) {
       // Sanitize job.label for use as a Windows directory name —
@@ -437,14 +440,49 @@ async function main(): Promise<void> {
         ffmpegPath,
         audioPath,
       });
+
+      // Dead-air compression. The narration recording is full of
+      // multi-second silences between moves (the commentator LLM is
+      // generating the next move's text while the previous TTS clip
+      // has already finished). Detecting + trimming those silences
+      // typically cuts 30-50% off the video duration without losing
+      // any narrated content. Only runs when there's an audio track
+      // to analyze — silent MP4s pass through unchanged.
+      let tightOutputPath: string | undefined;
+      let compressedRemovedS = 0;
+      if (audioPath && audioBytes > 0) {
+        tightOutputPath = job.outputPath.replace(/\.mp4$/, '_tight.mp4');
+        try {
+          const result = await compressDeadAir({
+            inputPath: job.outputPath,
+            outputPath: tightOutputPath,
+            ffmpegPath,
+          });
+          compressedRemovedS = result.removedS;
+          console.log(
+            `[dead-air] ${path.basename(job.outputPath)}: ${result.inputDurationS.toFixed(1)}s → ${result.outputDurationS.toFixed(1)}s (removed ${result.removedS.toFixed(1)}s, ${result.silenceRanges.length} silence ranges)`,
+          );
+        } catch (err) {
+          console.warn(
+            `[dead-air] compression failed for ${path.basename(job.outputPath)}: ${err instanceof Error ? err.message : String(err)}. The uncompressed MP4 is still usable.`,
+          );
+          tightOutputPath = undefined;
+        }
+      }
+
       captures.push({
         job,
         segmentTimings: capture.segmentTimings,
         durationMs: capture.durationMs,
         frameCount: capture.frameCount,
         audioBytes,
+        tightOutputPath,
+        compressedRemovedS,
       });
       console.log(`[export] wrote ${path.relative(repoRoot, job.outputPath)}`);
+      if (tightOutputPath) {
+        console.log(`[export] wrote ${path.relative(repoRoot, tightOutputPath)} (dead air removed)`);
+      }
     }
 
     // Use the FULL capture's timings (if present) for retiming. Short
@@ -475,6 +513,8 @@ async function main(): Promise<void> {
             label: c.job.label,
             shortId: c.job.shortId,
             outputPath: path.relative(repoRoot, c.job.outputPath),
+            tightOutputPath: c.tightOutputPath ? path.relative(repoRoot, c.tightOutputPath) : undefined,
+            compressedRemovedS: c.compressedRemovedS,
             viewport: c.job.viewport,
             frameCount: c.frameCount,
             durationMs: c.durationMs,

--- a/scripts/lib/export/browserCapture.ts
+++ b/scripts/lib/export/browserCapture.ts
@@ -114,8 +114,24 @@ export async function recordBroadcastPlayback(browser: Browser, options: Capture
   const page = await context.newPage();
   const consoleEntries: BrowserConsoleEntry[] = [];
   page.on('console', (message) => {
+    const text = message.text();
     if (message.type() === 'error' || message.type() === 'warning') {
-      consoleEntries.push({ type: message.type(), text: message.text() });
+      consoleEntries.push({ type: message.type(), text });
+    }
+    // Surface broadcast-specific diagnostics to the export stdout so
+    // a silent capture is debuggable without re-running with Playwright
+    // in non-headless mode. Filter narrowly so we don't pull in
+    // unrelated Vite HMR noise.
+    if (
+      text.startsWith('[broadcast]')
+      || text.startsWith('[seed]')
+      || text.startsWith('[__CHESS_EXPORT__]')
+      || text.startsWith('[Commentary]')
+      || text.startsWith('[Replay]')
+      || text.startsWith('[TTS')
+      || text.startsWith('[OpenAI]')
+    ) {
+      console.log(`[page] ${text}`);
     }
   });
   page.on('pageerror', (error) => {
@@ -219,6 +235,24 @@ export async function recordBroadcastPlayback(browser: Browser, options: Capture
  * via the migrate function on first hydrate.
  */
 function seedTtsSettingsScript(tts: TtsExportConfig): string {
+  // OpenAI's API key serves double duty in this project: TTS synthesis
+  // AND the commentary LLM. For headless captures we ALWAYS seed both:
+  // commentary generation runs through `apiKey` / `providerKeys`, and
+  // its output is what gets handed to TTS. Without the LLM key, the
+  // CommentaryQueue silently fails to produce text, no audio plays,
+  // and the replay races to the end with paceWithNarration unable to
+  // catch anything to wait on.
+  //
+  // Qwen-cloud and local providers don't double for LLM duty; we leave
+  // the LLM provider/key empty in those cases (commentary won't run
+  // and the audio output will be silent — that's the user's choice).
+  const seedLlmFields = tts.provider === 'openai' && tts.apiKey
+    ? {
+        provider: 'openai',
+        apiKey: tts.apiKey,
+        providerKeys: { openrouter: '', openai: tts.apiKey },
+      }
+    : {};
   const payload = {
     state: {
       ttsEnabled: true,
@@ -228,6 +262,7 @@ function seedTtsSettingsScript(tts: TtsExportConfig): string {
       ttsVoice: tts.voice ?? 'default',
       ttsVolume: tts.volume ?? 0.8,
       ttsPort: tts.port ?? 9877,
+      ...seedLlmFields,
     },
     version: 8,
   };
@@ -250,16 +285,17 @@ function seedTtsSettingsScript(tts: TtsExportConfig): string {
               version: incoming.version,
             };
             localStorage.setItem(KEY, JSON.stringify(merged));
+            console.log('[seed] merged into existing settings (ttsEnabled=' + merged.state.ttsEnabled + ', provider=' + merged.state.ttsProvider + ', hasKey=' + Boolean(merged.state.ttsCloudApiKey) + ')');
           } catch (_e) {
             localStorage.setItem(KEY, JSON.stringify(incoming));
+            console.log('[seed] wrote fresh settings after parse error (ttsEnabled=' + incoming.state.ttsEnabled + ')');
           }
         } else {
           localStorage.setItem(KEY, JSON.stringify(incoming));
+          console.log('[seed] wrote fresh settings (ttsEnabled=' + incoming.state.ttsEnabled + ', provider=' + incoming.state.ttsProvider + ', hasKey=' + Boolean(incoming.state.ttsCloudApiKey) + ')');
         }
-      } catch (_e) {
-        // localStorage may be unavailable (private mode, etc.); the
-        // SPA falls back to its schema defaults (TTS off) and the
-        // capture pipeline will warn about no audio.
+      } catch (e) {
+        console.log('[seed] error: ' + (e && e.message));
       }
     })();
   `;

--- a/scripts/lib/export/compressDeadAir.ts
+++ b/scripts/lib/export/compressDeadAir.ts
@@ -1,0 +1,270 @@
+/**
+ * Dead-air compression for MP4 exports.
+ *
+ * After the SPA capture finishes, the recorded narration has long
+ * silent gaps where the commentator LLM was generating the NEXT
+ * move's text and the TTS hadn't started yet. Those silences also
+ * mean the video has multiple seconds per move of "dead air" —
+ * board sits still, no narration, no useful content.
+ *
+ * Approach:
+ *   1. Run ffmpeg with the `silencedetect` audio filter on the input
+ *      MP4. Parse the stderr log for "silence_start" / "silence_end"
+ *      timestamps.
+ *   2. Convert those silence ranges to KEEP ranges (their complement),
+ *      optionally preserving a small head/tail buffer (default 0.4s)
+ *      so word boundaries don't get clipped.
+ *   3. Run a second ffmpeg pass with a filter_complex that trims to
+ *      each keep range and concatenates them. Audio + video stay
+ *      perfectly synced because the same trim ranges drive both.
+ *
+ * Tunables (defaults are conservative for chess narration):
+ *   - silenceThresholdDb: dBFS below which audio is considered silent (-30)
+ *   - minSilenceDurationS: silences shorter than this are kept as-is (0.6)
+ *   - keepHeadMs / keepTailMs: padding around each kept segment (400 ms)
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { registerPid } from './processRegistry';
+
+export interface CompressDeadAirOptions {
+  /** Input MP4 (with audio) produced by the first compose pass. */
+  inputPath: string;
+  /** Output MP4 (compressed). Typically `<slug>_tight.mp4`. */
+  outputPath: string;
+  /** Absolute path to the ffmpeg binary. */
+  ffmpegPath: string;
+  /** dBFS threshold for silence detection. Default -30. */
+  silenceThresholdDb?: number;
+  /** Silences shorter than this stay as-is. Default 0.6s. */
+  minSilenceDurationS?: number;
+  /** Pad before/after each kept segment, ms. Default 400. */
+  keepHeadMs?: number;
+  keepTailMs?: number;
+}
+
+export interface CompressDeadAirResult {
+  inputPath: string;
+  outputPath: string;
+  inputDurationS: number;
+  outputDurationS: number;
+  removedS: number;
+  silenceRanges: Array<{ startS: number; endS: number }>;
+}
+
+interface SilenceRange {
+  startS: number;
+  endS: number;
+}
+
+/**
+ * Run silencedetect to enumerate silent ranges. Returns a sorted,
+ * merged list of {start, end} pairs in seconds.
+ */
+async function detectSilences(opts: CompressDeadAirOptions): Promise<SilenceRange[]> {
+  const thresh = opts.silenceThresholdDb ?? -30;
+  const minD = opts.minSilenceDurationS ?? 0.6;
+  const args = [
+    '-i',
+    opts.inputPath,
+    '-af',
+    `silencedetect=noise=${thresh}dB:duration=${minD}`,
+    '-f',
+    'null',
+    '-',
+  ];
+  const stderr = await captureStderr(opts.ffmpegPath, args);
+  const ranges: SilenceRange[] = [];
+  let pendingStart: number | null = null;
+  for (const line of stderr.split(/\r?\n/)) {
+    const m1 = line.match(/silence_start:\s*([0-9.]+)/);
+    if (m1) {
+      pendingStart = Number(m1[1]);
+      continue;
+    }
+    const m2 = line.match(/silence_end:\s*([0-9.]+)/);
+    if (m2 && pendingStart !== null) {
+      ranges.push({ startS: pendingStart, endS: Number(m2[1]) });
+      pendingStart = null;
+    }
+  }
+  return ranges;
+}
+
+/**
+ * Probe the duration of the input MP4. Used so the final silence
+ * range (if the file ends in silence) can be closed at file end.
+ */
+async function probeDuration(ffmpegPath: string, inputPath: string): Promise<number> {
+  const stderr = await captureStderr(ffmpegPath, ['-i', inputPath]);
+  const m = stderr.match(/Duration:\s*(\d{2}):(\d{2}):([0-9.]+)/);
+  if (!m) throw new Error(`Could not probe duration of ${inputPath}`);
+  return Number(m[1]) * 3600 + Number(m[2]) * 60 + Number(m[3]);
+}
+
+/**
+ * Convert silence ranges to keep ranges. Keep ranges are the
+ * complement of the silence ranges, padded by keepHeadMs / keepTailMs.
+ * Overlapping keeps are merged.
+ */
+function buildKeepRanges(
+  silences: SilenceRange[],
+  durationS: number,
+  keepHeadMs: number,
+  keepTailMs: number,
+): SilenceRange[] {
+  if (silences.length === 0) {
+    return [{ startS: 0, endS: durationS }];
+  }
+  const sorted = [...silences].sort((a, b) => a.startS - b.startS);
+  const keeps: SilenceRange[] = [];
+  let cursor = 0;
+  for (const sil of sorted) {
+    const keepEnd = sil.startS + keepTailMs / 1000;
+    if (keepEnd > cursor) keeps.push({ startS: cursor, endS: keepEnd });
+    cursor = Math.max(cursor, sil.endS - keepHeadMs / 1000);
+  }
+  if (cursor < durationS) keeps.push({ startS: cursor, endS: durationS });
+  // Drop zero-or-negative-length keeps; merge any back-to-back keeps.
+  const cleaned: SilenceRange[] = [];
+  for (const k of keeps) {
+    if (k.endS <= k.startS) continue;
+    const last = cleaned[cleaned.length - 1];
+    if (last && k.startS - last.endS < 0.05) {
+      last.endS = Math.max(last.endS, k.endS);
+    } else {
+      cleaned.push({ ...k });
+    }
+  }
+  return cleaned;
+}
+
+/**
+ * Build the ffmpeg filter_complex string for a list of keep ranges.
+ * Trim video + audio to each range, then concat them in order.
+ */
+function buildTrimConcatFilter(keeps: SilenceRange[]): string {
+  const parts: string[] = [];
+  for (let i = 0; i < keeps.length; i++) {
+    const { startS, endS } = keeps[i];
+    parts.push(`[0:v]trim=start=${startS}:end=${endS},setpts=PTS-STARTPTS[v${i}]`);
+    parts.push(`[0:a]atrim=start=${startS}:end=${endS},asetpts=PTS-STARTPTS[a${i}]`);
+  }
+  const labels = keeps.map((_, i) => `[v${i}][a${i}]`).join('');
+  parts.push(`${labels}concat=n=${keeps.length}:v=1:a=1[outv][outa]`);
+  return parts.join(';');
+}
+
+export async function compressDeadAir(opts: CompressDeadAirOptions): Promise<CompressDeadAirResult> {
+  const inputExists = await stat(opts.inputPath).then(() => true).catch(() => false);
+  if (!inputExists) throw new Error(`compressDeadAir: input not found: ${opts.inputPath}`);
+  await mkdir(path.dirname(opts.outputPath), { recursive: true });
+
+  const inputDurationS = await probeDuration(opts.ffmpegPath, opts.inputPath);
+  const silences = await detectSilences(opts);
+  console.log(
+    `[dead-air] ${silences.length} silence range(s) detected (>${opts.minSilenceDurationS ?? 0.6}s @ ${opts.silenceThresholdDb ?? -30}dB)`,
+  );
+
+  if (silences.length === 0) {
+    // Nothing to compress; copy through unchanged so callers can
+    // always rely on outputPath existing.
+    await runFfmpeg(opts.ffmpegPath, ['-y', '-i', opts.inputPath, '-c', 'copy', opts.outputPath]);
+    return {
+      inputPath: opts.inputPath,
+      outputPath: opts.outputPath,
+      inputDurationS,
+      outputDurationS: inputDurationS,
+      removedS: 0,
+      silenceRanges: silences,
+    };
+  }
+
+  const keeps = buildKeepRanges(silences, inputDurationS, opts.keepHeadMs ?? 400, opts.keepTailMs ?? 400);
+  if (keeps.length === 0) {
+    throw new Error('[dead-air] All audio detected as silence — refusing to produce an empty MP4.');
+  }
+  const filter = buildTrimConcatFilter(keeps);
+  const args = [
+    '-y',
+    '-i',
+    opts.inputPath,
+    '-filter_complex',
+    filter,
+    '-map',
+    '[outv]',
+    '-map',
+    '[outa]',
+    '-c:v',
+    'libx264',
+    '-pix_fmt',
+    'yuv420p',
+    '-preset',
+    'veryfast',
+    '-crf',
+    '20',
+    '-movflags',
+    '+faststart',
+    '-c:a',
+    'aac',
+    '-b:a',
+    '160k',
+    opts.outputPath,
+  ];
+  await runFfmpeg(opts.ffmpegPath, args);
+  const outputDurationS = await probeDuration(opts.ffmpegPath, opts.outputPath);
+  return {
+    inputPath: opts.inputPath,
+    outputPath: opts.outputPath,
+    inputDurationS,
+    outputDurationS,
+    removedS: inputDurationS - outputDurationS,
+    silenceRanges: silences,
+  };
+}
+
+function captureStderr(ffmpegPath: string, args: string[]): Promise<string> {
+  return new Promise<string>((resolve) => {
+    // ffmpeg writes its log to stderr; -f null - sends video to /dev/null
+    const child: ChildProcess = spawn(ffmpegPath, args, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      windowsHide: true,
+    });
+    if (child.pid !== undefined) {
+      const unregister = registerPid(child.pid);
+      child.once('exit', unregister);
+    }
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    // silencedetect runs as a side-effect of decoding; exit code may
+    // be non-zero when ffmpeg can't produce the null sink on some
+    // versions, but the stderr log is what we need either way.
+    child.once('exit', () => resolve(stderr));
+  });
+}
+
+function runFfmpeg(ffmpegPath: string, args: string[]): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const child: ChildProcess = spawn(ffmpegPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    if (child.pid !== undefined) {
+      const unregister = registerPid(child.pid);
+      child.once('exit', unregister);
+    }
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`ffmpeg exited with code ${code}\n--- stderr tail ---\n${stderr.slice(-2000)}`));
+    });
+  });
+}

--- a/scripts/lib/export/frameSequenceWriter.ts
+++ b/scripts/lib/export/frameSequenceWriter.ts
@@ -78,8 +78,18 @@ export class FrameSequenceWriter {
     const sorted = [...this.buffer].sort((a, b) => a.receivedMs - b.receivedMs);
 
     const frameCount = Math.max(1, Math.round((captureDurationMs / 1000) * this.frameRate));
+
+    // Batched writes. Promise.all over 8000+ files at once exhausts
+    // the Windows file-descriptor limit (EMFILE). 128 in flight at
+    // a time keeps disk throughput high without saturating the FD pool.
+    const CONCURRENCY = 128;
     let cursor = 0; // index into `sorted` of the current "active" frame
     const writes: Promise<void>[] = [];
+    const flushBatch = async (): Promise<void> => {
+      if (writes.length === 0) return;
+      await Promise.all(writes);
+      writes.length = 0;
+    };
     for (let i = 0; i < frameCount; i++) {
       const slotMs = i * this.intervalMs;
       // Advance the cursor to the latest frame whose timestamp <= slotMs.
@@ -89,8 +99,9 @@ export class FrameSequenceWriter {
       const frame = sorted[cursor];
       const file = path.join(this.frameDir, `frame_${String(i).padStart(8, '0')}.jpg`);
       writes.push(writeFile(file, frame.data));
+      if (writes.length >= CONCURRENCY) await flushBatch();
     }
-    await Promise.all(writes);
+    await flushBatch();
     return frameCount;
   }
 }

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -6,7 +6,7 @@ import { exportBridge } from '../app/exportBridge';
 import { getEpisode, DEFAULT_EPISODE_ID } from '../episodes';
 import { TournamentProgress } from './TournamentProgress';
 import { BroadcastLayout } from './BroadcastLayout';
-import { getActiveAudioNarrationQueue } from '../tts/audio-queue';
+import { getActiveAudioNarrationQueue, runWhenAudioNarrationQueueAvailable } from '../tts/audio-queue';
 import { createRenderPlanFromPgn, type RenderPlan } from '../production/renderPlan';
 
 /**
@@ -66,13 +66,18 @@ export function BroadcastView() {
         id: '',
         name: '',
         mode: 'llm' as const,
-        reasoningEffort: 'high' as const,
-        maxTokens: 16000,
         stockfishDepth: 18,
       }),
       id: episodeCommentatorModel,
       name: episodeCommentatorModel,
       mode: 'llm',
+      // Video-friendly defaults. The SPA's default for replay is
+      // reasoning_effort: 'high' + 16000 tokens, which produces 30-
+      // 130s LLM calls and 3-6 minute TTS narrations per move —
+      // overkill for a video clip. Medium + 1500 tokens gives
+      // ~5-15s commentary blocks, narratable in 15-30 seconds.
+      reasoningEffort: 'medium',
+      maxTokens: 1500,
     });
   }, [episodeCommentatorModel, setReplayCommentatorModel]);
 
@@ -94,6 +99,20 @@ export function BroadcastView() {
         }
         startedRef.current = true;
 
+        // Phase 3.1 diagnostic: emit the SPA's effective settings
+        // at start() so the capture log proves whether the seeded
+        // localStorage actually hydrated into the settings store.
+        // Both TTS and LLM-commentator settings matter — without the
+        // commentator key, CommentaryQueue silently fails to produce
+        // text and no audio plays even when TTS is enabled.
+        const settings = useSettingsStore.getState();
+        console.log(
+          `[broadcast] tts: enabled=${settings.ttsEnabled} provider=${settings.ttsProvider} hasCloudKey=${Boolean(settings.ttsCloudApiKey)} voice=${settings.ttsCloudVoice}`,
+        );
+        console.log(
+          `[broadcast] llm: provider=${settings.provider} hasKey=${Boolean(settings.apiKey)} keyLen=${settings.apiKey?.length ?? 0}`,
+        );
+
         const config = getBroadcastConfig();
         const plan: RenderPlan = createRenderPlanFromPgn({
           id: config.episodeId ?? 'inline-pgn',
@@ -104,26 +123,32 @@ export function BroadcastView() {
         });
         exportBridge.__setRenderPlan(plan);
 
-        const audioQueue = getActiveAudioNarrationQueue();
-        if (audioQueue) {
-          audioQueue.markPlaybackStart(performance.now());
+        // Race-safe queue hooks: CommentaryPanel mounts AFTER
+        // startReplay flips replayMode, so the AudioNarrationQueue
+        // doesn't exist yet at this moment. runWhenAvailable fires
+        // the callback immediately if a queue is registered, OR as
+        // soon as register() is next called. Either way, the
+        // MediaRecorder is attached to the SAME instance that plays
+        // the narration audio.
+        const playbackStartedAt = performance.now();
+        runWhenAudioNarrationQueueAvailable((audioQueue) => {
+          console.log('[broadcast] attaching MediaRecorder + segment-start callback to audio queue');
+          audioQueue.markPlaybackStart(playbackStartedAt);
           audioQueue.setSegmentStartCallback((moveIndex, offsetMs) => {
             exportBridge.__recordSegmentTiming(moveIndex, offsetMs);
           });
-          // Phase 3.1: tap the queue's gain node via MediaRecorder
-          // so the capture pipeline can mux the rendered narration
-          // into the final MP4. No-op when TTS is disabled (queue
-          // never plays anything).
           audioQueue.startRecording();
-        } else {
-          console.warn(
-            '[BroadcastView] No active AudioNarrationQueue at start() — segment timings will not be recorded',
-          );
-        }
+        });
 
         startReplay(pgnText, {
           historicalContext,
-          moveDelayMs: 0,
+          // Broadcast mode: each move waits on commentary + narration
+          // before the next fires (paceWithNarration). A small
+          // moveDelayMs gives the FIRST move's commentary time to
+          // start streaming before the second move fires — the pace
+          // check only runs from move 2 onward.
+          moveDelayMs: 2000,
+          paceWithNarration: true,
           startFromPly: shortRange?.startPly ?? 0,
         });
       },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,8 +16,10 @@ installExportBridge(broadcastConfig.exportMode);
 // App.tsx) keeps App's hook order stable for the normal SPA case.
 const Root = broadcastConfig.exportMode ? BroadcastView : App;
 
+// StrictMode is wrapped only for the normal SPA. In broadcast mode it
+// double-mounts CommentaryPanel, which throws away the AudioNarrationQueue
+// instance our MediaRecorder is attached to and silently produces an
+// empty audio track in the final MP4.
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <Root />
-  </StrictMode>,
+  broadcastConfig.exportMode ? <Root /> : <StrictMode><Root /></StrictMode>,
 )

--- a/src/store/tournamentStore.ts
+++ b/src/store/tournamentStore.ts
@@ -150,7 +150,7 @@ interface TournamentStore {
   resumeGame: (matchIndex: number, pairIndex: number, slotIndex: 0 | 1) => void;
 
   // Replay actions
-  startReplay: (pgn: string, config: { historicalContext?: string; moveDelayMs?: number; startFromPly?: number }) => void;
+  startReplay: (pgn: string, config: { historicalContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean }) => void;
   stopReplay: () => void;
 
   // Multi-tournament actions
@@ -635,7 +635,7 @@ export const useTournamentStore = create<TournamentStore>()(
 
       // --- Replay actions ---
 
-      startReplay: (pgn: string, config: { historicalContext?: string; moveDelayMs?: number; startFromPly?: number }) => {
+      startReplay: (pgn: string, config: { historicalContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean }) => {
         const { activeRuntime } = get();
         if (activeRuntime) {
           activeRuntime.abort('Starting replay');
@@ -713,9 +713,29 @@ export const useTournamentStore = create<TournamentStore>()(
           useTournamentStore.setState({ streamingText: text, streamingModel: model });
         });
 
-        // No gate needed — moves fire with a simple delay (like LLM think time),
-        // commentary + TTS run async in the background at their own pace.
-        // Board display follows narration via effectiveMoveIndex (same as tournament).
+        // Pace control. The default replay path uses moveDelayMs and
+        // lets commentary + TTS run async — which works for the live
+        // UX where the user can watch the board while narration catches
+        // up. The MP4 export pipeline needs the OPPOSITE: each move
+        // must wait for the previous narration to finish playing AND
+        // for the next move's commentary to be generated, so the
+        // captured video stays synced to the narration audio.
+        //
+        // When paceWithNarration is set, install a replayPaceCheck
+        // that drains both queues between moves. The runtime awaits
+        // this before emitting each MoveApplied event (except the very
+        // first; we add a short pre-roll for the opener's commentary
+        // separately).
+        if (config.paceWithNarration) {
+          runtime.setReplayPaceCheck(async () => {
+            if (_commentaryQueue) {
+              try { await _commentaryQueue.waitUntilIdle(); } catch { /* commentary failure shouldn't block replay */ }
+            }
+            if (_waitForNarration) {
+              try { await _waitForNarration(); } catch { /* same */ }
+            }
+          });
+        }
 
         runtime.subscribe((state: GameState, event: GameEvent) => {
           useTournamentStore.setState({ activeGameState: state });

--- a/src/tts/audio-queue.ts
+++ b/src/tts/audio-queue.ts
@@ -527,26 +527,54 @@ function stripMarkdownForTts(text: string): string {
 // ─── Active-queue registry (broadcast mode) ─────────────────────────
 //
 // CommentaryPanel creates an AudioNarrationQueue per session. The
-// MP4-export pipeline (BroadcastView in Phase 1, scripts/lib/export in
-// Phase 3) needs to reach the currently-active queue to call
-// markPlaybackStart() and setSegmentStartCallback(). Following the
-// existing registerCommentaryQueue pattern in tournamentStore, expose
-// a module-level slot. Outside broadcast mode this slot is set but
-// nobody reads it.
+// MP4-export pipeline needs to reach the active queue to call
+// markPlaybackStart() / setSegmentStartCallback() / startRecording().
+//
+// Race: bridge.start() fires BEFORE startReplay flips replayMode, so
+// TournamentProgress hasn't rendered CommentaryPanel yet → the queue
+// isn't registered yet. To handle this, the registry supports
+// "pending hooks": callers can `runWhenAudioNarrationQueueAvailable(fn)`
+// and the fn runs either immediately (queue exists) or when register
+// is next called.
 
 let activeAudioNarrationQueue: AudioNarrationQueue | null = null;
+const pendingHooks: ((queue: AudioNarrationQueue) => void)[] = [];
 
 /**
  * Register the audio narration queue currently driving playback. Called
  * by CommentaryPanel on mount. Unregister with null on unmount.
+ * Pending hooks queued via runWhenAudioNarrationQueueAvailable fire
+ * on the first non-null register since they were added.
  */
 export function registerAudioNarrationQueue(queue: AudioNarrationQueue | null): void {
   activeAudioNarrationQueue = queue;
+  if (queue && pendingHooks.length > 0) {
+    const hooks = pendingHooks.splice(0, pendingHooks.length);
+    for (const hook of hooks) {
+      try { hook(queue); } catch (err) { console.warn('[AudioQueue] pending hook failed:', err); }
+    }
+  }
 }
 
 /** Returns the active audio narration queue, if any. */
 export function getActiveAudioNarrationQueue(): AudioNarrationQueue | null {
   return activeAudioNarrationQueue;
+}
+
+/**
+ * Run `fn` against the active audio queue — immediately if one is
+ * already registered, otherwise as soon as the next register() call
+ * lands. Used by the MP4 broadcast bridge to install
+ * markPlaybackStart + startRecording the moment CommentaryPanel
+ * mounts, even when bridge.start() fires before TournamentProgress
+ * has flipped to replay mode.
+ */
+export function runWhenAudioNarrationQueueAvailable(fn: (queue: AudioNarrationQueue) => void): void {
+  if (activeAudioNarrationQueue) {
+    fn(activeAudioNarrationQueue);
+    return;
+  }
+  pendingHooks.push(fn);
 }
 
 /**


### PR DESCRIPTION
## Summary

This is the bundle of fixes that finally made `npm run export:game --short=opera_game_combination` produce a **real audio-bearing video** instead of a silent speedrun. Verified end-to-end with a 5:10 tight short of Morphy's Opera Game combination, narrated by `gpt-5.5` (medium reasoning) + OpenAI TTS (nova voice).

Five separate bugs were chained together — each masked the next:

### 1. Replay had no narration gate

`tournamentStore.startReplay` set up a `GameRuntime` with `moveDelayMs` only — moves fired at a fixed delay regardless of whether TTS audio had finished. With `moveDelayMs: 0` (broadcast default), the entire game completed in milliseconds before commentary could even start.

**Fix:** `paceWithNarration: true` option on `startReplay` installs a `replayPaceCheck` that drains both the `CommentaryQueue` and the audio queue between moves. The runtime awaits this before emitting each `MoveApplied` from move 2 onward. The first move has a small `moveDelayMs: 2000` pre-roll for the opener.

### 2. LLM key wasn't seeded

The TTS seed script wrote `ttsCloudApiKey` and `ttsEnabled: true`, but the SPA's commentary LLM reads `apiKey` and `providerKeys` separately. With no LLM key, `CommentaryQueue` silently failed to produce text, no audio played, replay raced to the end.

**Fix:** when `CHESS_TTS_PROVIDER=openai`, the seed script also sets `provider: 'openai'`, `apiKey`, and `providerKeys.openai`. Qwen and local providers don't double for LLM duty.

### 3. `AudioNarrationQueue` race

`bridge.start()` fires BEFORE `startReplay` flips `replayMode`, which is when `TournamentProgress` first renders `CommentaryPanel` and the `AudioNarrationQueue` gets registered. So `getActiveAudioNarrationQueue()` returned null at start time, my `startRecording()` was a no-op, and the queue that actually played audio had no `MediaRecorder` attached.

**Fix:** new `runWhenAudioNarrationQueueAvailable(fn)` helper. Fires `fn` immediately if a queue is registered, or queues it for the next `register` call.

### 4. React StrictMode destroyed the queue

Even when the race was resolved, StrictMode's dev-mode double-invocation unmounted `CommentaryPanel` between mount and re-mount, throwing away the `AudioNarrationQueue` instance the `MediaRecorder` was attached to.

**Fix:** bypass `StrictMode` in broadcast mode.

### 5. EMFILE on frame finalize

`FrameSequenceWriter` did `Promise.all(writes)` over all frames (8k+ for a 5-minute capture) at once, blowing the Windows file-descriptor limit.

**Fix:** batched writes, 128 in flight at a time.

### Other changes

- **Video-friendly commentator defaults** in `BroadcastView`: `reasoning_effort: 'medium'` + `maxTokens: 1500` instead of `'high'` + 16000. 5× faster generation, narration blocks that fit a Short.
- **Dead-air compression** (`scripts/lib/export/compressDeadAir.ts`): runs `ffmpeg silencedetect` on the muxed MP4, parses silent ranges, builds a `trim+atrim+concat` filter_complex that keeps only non-silent segments (with 400 ms head/tail padding). Video and audio stay synced. Emits `<slug>_tight.mp4` alongside the original.
- **Page-side log forwarding** in `browserCapture`: `[Commentary]`, `[Replay]`, `[TTS]`, `[OpenAI]` logs surface to the export stdout for debugging without a non-headless browser.

### Verified output

```
exports/opera_game_morphy_1858/shorts/
  opera_game_morphy_1858__opera_game_combination.mp4         14.5 MB, 6:52
  opera_game_morphy_1858__opera_game_combination_tight.mp4   12.7 MB, 5:10
```

Both H.264 1080×1920 + AAC 160 kbps. The `_tight` version has **102 seconds of dead air removed across 38 silence ranges**. Narration covers Rxd7 → Rxd7 → Rd1 → Qe6 → Bxd7+ → Nxd7 → Qb8+!! → Nxb8 → Rd8#.

### Test plan

- [x] `npm run build` clean
- [x] End-to-end: `CHESS_TTS_PROVIDER=openai` + key in `.env` + `npm run export:game -- --episode opera_game_morphy_1858 --short=opera_game_combination --fast`
- [x] Capture log shows `[broadcast] attaching MediaRecorder + segment-start callback to audio queue`
- [x] Final stats: `captured 12378 frames in 412.6 s, 8 segment timings, 5042 KB audio`
- [x] ffprobe: video has AAC audio track @ 160 kbps stereo
- [x] Dead-air compression: `412.3s → 310.3s (removed 102.0s, 38 silence ranges)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dead-air compression automatically trims narration silences from exported MP4 files, generating a "tight" version alongside the standard output.

* **Improvements**
  * Enhanced synchronization between replay progression and audio narration during exports.
  * Expanded OpenAI LLM integration support for text-to-speech settings.
  * Improved diagnostic logging for headless video captures.
  * Optimized frame writing performance with batched asynchronous operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->