### PR TITLE
feat(mp4-export): atomic narration sync — board + caption + annotations

### DIFF
--- a/src/components/BroadcastLayout.tsx
+++ b/src/components/BroadcastLayout.tsx
@@ -19,6 +19,9 @@ import type { EvalResult } from '../chess/stockfish';
 import { formatEval } from '../chess/stockfish';
 import { Board } from './Board';
 import type { CommentaryEntry } from '../commentary/commentaryQueue';
+import type { NarrationMove } from '../tts/audio-queue';
+import type { BoardAnnotations } from '../utils/board-annotations';
+import type { GameEvent } from '../engine/events';
 
 interface BroadcastLayoutProps {
   gameState: GameState;
@@ -33,19 +36,63 @@ interface BroadcastLayoutProps {
   subtitle?: string;
   /** 'full' = 1920x1080 (landscape); 'short' = 1080x1920 (portrait). */
   orientation: 'full' | 'short';
-  /** Last move played, for board highlighting. */
+  /**
+   * Last move played (latest runtime state). Used as a fallback when
+   * no narration is active. When narrationMoveIndex >= 0 the lastMove
+   * is derived from the narrated position instead.
+   */
   lastMove?: { from: string; to: string };
+  /**
+   * Move index of the commentary currently being narrated. The board
+   * displays the position AFTER this move. -1 means no narration yet
+   * → board shows the latest applied position. Updated by
+   * BroadcastView from AudioNarrationQueue's entry-start callback.
+   */
+  narrationMoveIndex: number;
+  /** Squares to highlight (amber) — from the current sentence's text. */
+  narrationSquares: string[];
+  /** Model-driven board annotations parsed from inline tags. */
+  narrationAnnotations?: BoardAnnotations;
+  /** Move arrows for the currently-narrated move. */
+  narrationArrows: NarrationMove[];
 }
 
 /**
- * Resolve the latest move applied and its turn number for display.
- * In broadcast mode the board ALWAYS shows the latest position —
- * unlike the SPA which gates display on narration progress.
+ * Resolve the move whose narration is currently playing. When
+ * narrationMoveIndex >= 0, the displayed board should reflect the
+ * position AFTER that ply — even if the runtime has already advanced
+ * to a later move.
  */
-function lastMoveInfo(gameState: GameState): { san: string; turnNumber: number; color: 'w' | 'b' } | null {
-  const last = gameState.moveHistory[gameState.moveHistory.length - 1];
-  if (!last) return null;
-  return { san: last.move, turnNumber: last.turnNumber, color: last.color };
+function narratedMoveInfo(
+  gameState: GameState,
+  narrationMoveIndex: number,
+): { san: string; turnNumber: number; color: 'w' | 'b'; fen: string; from?: string; to?: string } | null {
+  const idx = narrationMoveIndex >= 0
+    ? Math.min(narrationMoveIndex, gameState.moveHistory.length - 1)
+    : gameState.moveHistory.length - 1;
+  if (idx < 0) return null;
+  const move = gameState.moveHistory[idx];
+  if (!move) return null;
+  // Find the MoveApplied event for this ply to recover its FEN +
+  // from/to. The eventLog stores them in order; the Nth MoveApplied
+  // corresponds to move index N.
+  let seen = 0;
+  for (const event of gameState.eventLog) {
+    if (event.type !== 'MoveApplied') continue;
+    if (seen === idx) {
+      const ev = event as Extract<GameEvent, { type: 'MoveApplied' }>;
+      return {
+        san: move.move,
+        turnNumber: move.turnNumber,
+        color: move.color,
+        fen: ev.payload.fen,
+        from: ev.payload.from,
+        to: ev.payload.to,
+      };
+    }
+    seen++;
+  }
+  return { san: move.move, turnNumber: move.turnNumber, color: move.color, fen: gameState.fen };
 }
 
 export function BroadcastLayout({
@@ -57,11 +104,28 @@ export function BroadcastLayout({
   subtitle,
   orientation,
   lastMove,
+  narrationMoveIndex,
+  narrationSquares,
+  narrationAnnotations,
+  narrationArrows,
 }: BroadcastLayoutProps) {
+  // The displayed board tracks the narrated move, not the runtime's
+  // latest. When narrationMoveIndex is -1 (no narration yet), fall
+  // back to the latest applied move. Truncating the displayed move
+  // history to narrationMoveIndex+1 also keeps the "recent moves"
+  // panel in sync (we don't list moves the narrator hasn't reached).
+  const effectiveMoveIndex = narrationMoveIndex >= 0 ? narrationMoveIndex : gameState.moveHistory.length - 1;
+  const displayedMoveHistory = gameState.moveHistory.slice(0, Math.max(0, effectiveMoveIndex + 1));
+  const narratedInfo = narratedMoveInfo(gameState, narrationMoveIndex);
+  const displayedFen = narratedInfo?.fen ?? gameState.fen;
+  const displayedLastMove =
+    narratedInfo && narratedInfo.from && narratedInfo.to
+      ? { from: narratedInfo.from, to: narratedInfo.to }
+      : lastMove;
+
   const recentMoves = useMemo(() => {
-    // Last 6 plies, formatted "16. Qb8+!! Nxb8".
-    const all = gameState.moveHistory;
-    const slice = all.slice(Math.max(0, all.length - 6));
+    // Last 6 plies of the DISPLAYED history (not the runtime's).
+    const slice = displayedMoveHistory.slice(Math.max(0, displayedMoveHistory.length - 6));
     const pairs: { turn: number; white?: string; black?: string }[] = [];
     for (const m of slice) {
       const last = pairs[pairs.length - 1];
@@ -74,11 +138,10 @@ export function BroadcastLayout({
       }
     }
     return pairs;
-  }, [gameState.moveHistory]);
+  }, [displayedMoveHistory]);
 
-  const moveInfo = lastMoveInfo(gameState);
-  const moveCounterText = moveInfo
-    ? `Move ${moveInfo.turnNumber}${moveInfo.color === 'b' ? '…' : ''} · ${moveInfo.san}`
+  const moveCounterText = narratedInfo
+    ? `Move ${narratedInfo.turnNumber}${narratedInfo.color === 'b' ? '…' : ''} · ${narratedInfo.san}`
     : 'Move 1';
 
   // Eval bar percentage. Clamps centipawns to ±500 then maps to 0..100%
@@ -101,8 +164,11 @@ export function BroadcastLayout({
 
   if (orientation === 'short') {
     return <ShortLayout
-      gameState={gameState}
-      lastMove={lastMove}
+      displayedFen={displayedFen}
+      lastMove={displayedLastMove}
+      narrationSquares={narrationSquares}
+      narrationAnnotations={narrationAnnotations}
+      narrationArrows={narrationArrows}
       title={title}
       subtitle={subtitle}
       moveCounterText={moveCounterText}
@@ -113,8 +179,11 @@ export function BroadcastLayout({
     />;
   }
   return <FullLayout
-    gameState={gameState}
-    lastMove={lastMove}
+    displayedFen={displayedFen}
+    lastMove={displayedLastMove}
+    narrationSquares={narrationSquares}
+    narrationAnnotations={narrationAnnotations}
+    narrationArrows={narrationArrows}
     title={title}
     subtitle={subtitle}
     moveCounterText={moveCounterText}
@@ -126,8 +195,11 @@ export function BroadcastLayout({
 }
 
 interface LayoutSlotProps {
-  gameState: GameState;
+  displayedFen: string;
   lastMove?: { from: string; to: string };
+  narrationSquares: string[];
+  narrationAnnotations?: BoardAnnotations;
+  narrationArrows: NarrationMove[];
   title: string;
   subtitle?: string;
   moveCounterText: string;
@@ -147,8 +219,11 @@ interface LayoutSlotProps {
  * visually centered inside the left half of a 1920x1080 frame.
  */
 function FullLayout({
-  gameState,
+  displayedFen,
   lastMove,
+  narrationSquares,
+  narrationAnnotations,
+  narrationArrows,
   title,
   subtitle,
   moveCounterText,
@@ -175,7 +250,13 @@ function FullLayout({
             chess geometry. */}
         <section className="flex-1 flex flex-col items-center justify-center px-10 min-w-0">
           <div style={{ zoom: 2.4 }}>
-            <Board fen={gameState.fen} lastMove={lastMove} />
+            <Board
+              fen={displayedFen}
+              lastMove={lastMove}
+              highlightSquares={narrationSquares}
+              arrows={narrationArrows}
+              annotations={narrationAnnotations}
+            />
           </div>
           <EvalBar pct={evalPct} label={evalLabel} className="mt-4 w-[600px]" />
         </section>
@@ -196,8 +277,11 @@ function FullLayout({
  * compact recent-moves row. Optimized for vertical phone consumption.
  */
 function ShortLayout({
-  gameState,
+  displayedFen,
   lastMove,
+  narrationSquares,
+  narrationAnnotations,
+  narrationArrows,
   title,
   subtitle,
   moveCounterText,
@@ -219,7 +303,13 @@ function ShortLayout({
           a thin border at 1080 px frame width. */}
       <section className="shrink-0 flex justify-center py-2">
         <div style={{ zoom: 2.7 }}>
-          <Board fen={gameState.fen} lastMove={lastMove} />
+          <Board
+            fen={displayedFen}
+            lastMove={lastMove}
+            highlightSquares={narrationSquares}
+            arrows={narrationArrows}
+            annotations={narrationAnnotations}
+          />
         </div>
       </section>
 

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -6,8 +6,9 @@ import { exportBridge } from '../app/exportBridge';
 import { getEpisode, DEFAULT_EPISODE_ID } from '../episodes';
 import { TournamentProgress } from './TournamentProgress';
 import { BroadcastLayout } from './BroadcastLayout';
-import { getActiveAudioNarrationQueue, runWhenAudioNarrationQueueAvailable } from '../tts/audio-queue';
+import { getActiveAudioNarrationQueue, runWhenAudioNarrationQueueAvailable, type NarrationMove } from '../tts/audio-queue';
 import { createRenderPlanFromPgn, type RenderPlan } from '../production/renderPlan';
+import type { BoardAnnotations } from '../utils/board-annotations';
 
 /**
  * BroadcastView — the chrome-free, auto-playing layout used by the
@@ -53,6 +54,23 @@ export function BroadcastView() {
   const endedRef = useRef(false);
   const commentatorAppliedRef = useRef(false);
 
+  // Narration sync state. Drives the DISPLAYED board (not the runtime
+  // state), so the visible position only advances when narration for
+  // that move actually starts playing. Without this, the runtime's
+  // moveDelayMs + pace-check let the board race ahead of the audio
+  // by 15-30s per move (commentary generation lag), producing video
+  // where the captions are about move N while the board is on N+1.
+  const [narrationMoveIndex, setNarrationMoveIndex] = useState(-1);
+  const [narrationSquares, setNarrationSquares] = useState<string[]>([]);
+  const [narrationAnnotations, setNarrationAnnotations] = useState<BoardAnnotations | undefined>();
+  const [narrationArrows, setNarrationArrows] = useState<NarrationMove[]>([]);
+  // The actual sentence currently being SPOKEN. Drives the caption
+  // panel — not streamingText (which is the LLM stream of whichever
+  // commentary block is generating, possibly several moves AHEAD of
+  // what's audible) and not the last completed commentaryLog entry
+  // (which can be several moves BEHIND if the LLM raced ahead).
+  const [activeNarrationText, setActiveNarrationText] = useState<string>('');
+
   // Apply the episode's commentator model id to the replay store
   // once. Reads existing config via getState() inside the effect so we
   // don't re-stomp the user's reasoning/verbosity settings on every
@@ -71,13 +89,16 @@ export function BroadcastView() {
       id: episodeCommentatorModel,
       name: episodeCommentatorModel,
       mode: 'llm',
-      // Video-friendly defaults. The SPA's default for replay is
-      // reasoning_effort: 'high' + 16000 tokens, which produces 30-
-      // 130s LLM calls and 3-6 minute TTS narrations per move —
-      // overkill for a video clip. Medium + 1500 tokens gives
-      // ~5-15s commentary blocks, narratable in 15-30 seconds.
-      reasoningEffort: 'medium',
-      maxTokens: 1500,
+      // Video-friendly defaults: HIGH reasoning (deep analysis under
+      // the hood) + BRIEF verbosity (terse, video-friendly output).
+      // This is the "think hard, talk less" pattern — the model still
+      // considers the position deeply but produces 1-3 sentence
+      // commentary blocks instead of 600-2000 token paragraphs.
+      // maxTokens caps the visible output; the reasoning tokens are
+      // separate and unlimited within the model's reasoning budget.
+      reasoningEffort: 'high',
+      verbosity: 'brief',
+      maxTokens: 400,
     });
   }, [episodeCommentatorModel, setReplayCommentatorModel]);
 
@@ -132,12 +153,38 @@ export function BroadcastView() {
         // the narration audio.
         const playbackStartedAt = performance.now();
         runWhenAudioNarrationQueueAvailable((audioQueue) => {
-          console.log('[broadcast] attaching MediaRecorder + segment-start callback to audio queue');
+          console.log('[broadcast] attaching audio queue hooks (recorder + narration sync)');
           audioQueue.markPlaybackStart(playbackStartedAt);
+          audioQueue.startRecording();
+          // Broadcast-only sentence callback. Survives CommentaryPanel's
+          // own setSentenceStartCallback calls — they overwrite the
+          // main callback slot, this one is independent. Fires on
+          // every sentence with the full payload + the entry's
+          // moveIndex, so the displayed board + caption + highlights
+          // all update atomically per sentence.
+          audioQueue.setBroadcastSentenceCallback((text, squares, annotations, maxMoveIndex) => {
+            if (text) setActiveNarrationText(text);
+            setNarrationSquares(squares);
+            setNarrationAnnotations(annotations);
+            if (maxMoveIndex !== undefined) {
+              setNarrationMoveIndex((prev) => Math.max(prev, maxMoveIndex));
+            }
+          });
+          // Segment-start still drives the export-bridge segment-
+          // timings record. It also bumps narrationMoveIndex defensively
+          // (in case the sentence callback dropped a frame). Both
+          // calls are idempotent.
           audioQueue.setSegmentStartCallback((moveIndex, offsetMs) => {
             exportBridge.__recordSegmentTiming(moveIndex, offsetMs);
+            setNarrationMoveIndex((prev) => Math.max(prev, moveIndex));
           });
-          audioQueue.startRecording();
+          // Entry-start: just the arrows. CommentaryPanel will
+          // overwrite this callback in its own effect; that's fine
+          // because the broadcast sentence callback covers the
+          // moveIndex update redundantly.
+          audioQueue.setEntryStartCallback((_maxMoveIndex, moves) => {
+            setNarrationArrows(moves);
+          });
         });
 
         startReplay(pgnText, {
@@ -271,7 +318,11 @@ export function BroadcastView() {
       </div>
       <BroadcastLayout
         gameState={activeGameState ?? emptyGameStatePlaceholder()}
-        liveCommentaryText={streamingText || ''}
+        // Caption shows the sentence currently being SPOKEN, not the
+        // (possibly future) LLM-streaming text. Fall back to
+        // streamingText when no sentence has played yet (e.g. during
+        // the pre-roll before the first TTS clip).
+        liveCommentaryText={activeNarrationText || streamingText || ''}
         commentaryEntries={commentaryEntries}
         stockfishEval={stockfishEval}
         title={episode?.title ?? 'Chess Game'}
@@ -280,6 +331,10 @@ export function BroadcastView() {
           (config.viewportHeight ?? 1080) > (config.viewportWidth ?? 1920) ? 'short' : 'full'
         }
         lastMove={lastMove}
+        narrationMoveIndex={narrationMoveIndex}
+        narrationSquares={narrationSquares}
+        narrationAnnotations={narrationAnnotations}
+        narrationArrows={narrationArrows}
       />
     </>
   );

--- a/src/tts/audio-queue.ts
+++ b/src/tts/audio-queue.ts
@@ -39,6 +39,21 @@ export type EntryStartCallback = (maxMoveIndex: number, moves: NarrationMove[], 
  * composing audio.
  */
 export type SegmentStartCallback = (maxMoveIndex: number, offsetMs: number) => void;
+/**
+ * Fires once per sentence — separate from setSentenceStartCallback so
+ * the broadcast pipeline can listen without conflicting with the SPA's
+ * own sentence-start handler (CommentaryPanel installs its own callback
+ * via setSentenceStartCallback after BroadcastView installs ours).
+ * Receives the full per-sentence payload: text + squares + annotations
+ * + the entry's maxMoveIndex.
+ */
+export type BroadcastSentenceCallback = (
+  text: string,
+  squares: string[],
+  annotations: BoardAnnotations,
+  maxMoveIndex: number | undefined,
+  entryId: string | undefined,
+) => void;
 
 /**
  * Sequential audio narration queue with per-sentence board sync.
@@ -63,6 +78,7 @@ export class AudioNarrationQueue {
   private onSentenceStart: SentenceStartCallback | null = null;
   private onEntryStart: EntryStartCallback | null = null;
   private onSegmentStart: SegmentStartCallback | null = null;
+  private onBroadcastSentence: BroadcastSentenceCallback | null = null;
   /** Tracks which entryId we last fired onEntryStart for. */
   private _lastFiredEntryId: string | null = null;
   /**
@@ -180,6 +196,17 @@ export class AudioNarrationQueue {
    */
   setSegmentStartCallback(cb: SegmentStartCallback | null): void {
     this.onSegmentStart = cb;
+  }
+
+  /**
+   * Set the broadcast-only sentence callback. Distinct from
+   * setSentenceStartCallback (which CommentaryPanel owns via its own
+   * useEffect chain) so the MP4 broadcast pipeline can subscribe
+   * without being overwritten when CommentaryPanel re-runs its
+   * effects. Fires on every sentence with full per-sentence payload.
+   */
+  setBroadcastSentenceCallback(cb: BroadcastSentenceCallback | null): void {
+    this.onBroadcastSentence = cb;
   }
 
   /**
@@ -430,6 +457,16 @@ export class AudioNarrationQueue {
 
         // Fire sentence start callback right before playback
         this.onSentenceStart?.(entry.text, entry.squares, entry.annotations);
+        // Broadcast pipeline mirrors sentence-start with full payload
+        // on its own callback slot (so it isn't clobbered by
+        // CommentaryPanel's setSentenceStartCallback).
+        this.onBroadcastSentence?.(
+          entry.text,
+          entry.squares,
+          entry.annotations,
+          entry.maxMoveIndex,
+          entry.entryId,
+        );
 
         // Fire segment-start callback when this sentence opens a new
         // commentary entry AND we're in broadcast mode (markPlaybackStart


### PR DESCRIPTION
## Summary

Direct response to user feedback on the first audio-bearing capture:

> turns are advancing simultaneously (each move should be analyzed standing on its own), tts narration does not match written commentary in the video, there are no board highlights or annotations, the position is over explained for a short (4 minutes)

All four issues fixed. Verified visually in the resulting MP4.

### What was broken

1. **Board ahead of narration** — `paceWithNarration` waited for the previous move's audio to drain, but commentary for the NEXT move takes 15–30 s to generate. The runtime emitted `MoveApplied` immediately when pace-check resolved; the displayed board jumped ahead while audio was still on the previous move.
2. **Caption mismatch with audio** — the caption panel was bound to `streamingText` (LLM streaming output, possibly several moves AHEAD of what was audible). Caption read move N+1 while audio still played move N.
3. **No board highlights or annotations** — `BroadcastLayout` passed only `fen` and `lastMove` to `Board`. The model's annotation tags (yellow circles, highlight squares) were parsed but never rendered.
4. **Over-explained for a Short** — commentary blocks were 600–2000 tokens at `reasoning_effort: high`. The user asked for "high reasoning, low verbosity".

### Critical bug that masked the above

**`CommentaryPanel.setSentenceStartCallback` was overwriting the broadcast handler.** Symptom: `narrationMoveIndex` advanced correctly (driven by `segment-start`, which `CommentaryPanel` doesn't touch) while `activeNarrationText` (driven by the overwritten `sentence-start`) stuck on the previous move.

Fix: new dedicated `setBroadcastSentenceCallback` slot on `AudioNarrationQueue` that fires alongside the existing `onSentenceStart` and is independent of `CommentaryPanel`'s lifecycle.

### Files changed

- **`src/tts/audio-queue.ts`** — `BroadcastSentenceCallback` type, `onBroadcastSentence` slot, `setBroadcastSentenceCallback(cb)`, fired in the playback loop with `(text, squares, annotations, maxMoveIndex, entryId)`.
- **`src/components/BroadcastView.tsx`** — local state for `narrationMoveIndex`, `narrationSquares`, `narrationAnnotations`, `narrationArrows`, `activeNarrationText`. All driven from the new broadcast sentence callback so they update atomically per sentence. Commentator defaults: `reasoningEffort: 'high'`, `verbosity: 'brief'`, `maxTokens: 400`.
- **`src/components/BroadcastLayout.tsx`** — new props for narration sync. `narratedMoveInfo()` recovers the FEN + from/to squares from `gameState.eventLog` for the currently-narrated ply. Board receives `highlightSquares`, `arrows`, `annotations`. Recent-moves panel uses the narrated slice of move history.

### Verified output

```
exports/opera_game_morphy_1858/shorts/
  opera_game_morphy_1858__opera_game_combination.mp4         6:14
  opera_game_morphy_1858__opera_game_combination_tight.mp4   3:30 (164s trim)
```

**Frame at t=60s of the tight short:**
- Title: "Move 13… · Rxd7"
- Board: black rook just landed on d7, **yellow annotation circle around it**, purple from-square highlight on d8
- Caption: "But the rook on d7 is now a target, not a savior — Morphy's remaining rook is ready to seize the d-file…"
- **All three signals match.**

**Frame at t=120s:**
- Title: "Move 15… · Nxd7"
- Board: black knight on d7 with yellow circle, purple from-square on f6
- Caption: "Nxd7 is a strong move: Black eliminates the checking bishop and gains a huge chunk of evaluation back…"

### Known limitations (follow-ups)

- **API-level verbosity parameter.** GPT-5.x supports `verbosity: 'low'` directly in the chat-completions request body. We're only sending the directive in the system prompt, which the model partially honors at high reasoning. Wiring the API parameter through `requestCommentaryStream` would give a strict cap.
- **Sentence-chunk granularity.** Captions still show one sentence at a time as the narrator speaks it; could be broken into shorter spoken-phrase chunks for readability.

### Test plan

- [x] `npm run build` clean
- [x] Capture runs end-to-end: `npm run export:game -- --episode opera_game_morphy_1858 --short=opera_game_combination --fast`
- [x] `[capture] captured 11230 frames in 374.3 s, 8 segment timings, 2786 KB audio`
- [x] `[dead-air] 374.1s → 210.4s (removed 163.7s, 21 silence ranges)`
- [x] Frame extraction confirms board + caption + annotations match at multiple timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Narration-synchronized board display: the board now updates in sync with audio playback position rather than always showing the latest game state.
  * Live commentary captions now properly sync with narration audio during playback.

* **Bug Fixes**
  * Improved synchronization between narration audio, highlighted squares, and board annotations during broadcast playback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->