### PR TITLE
fix(mp4-export): use parsed PGN for narrated FEN (replay mode off-by-one)

### DIFF
--- a/src/components/BroadcastLayout.tsx
+++ b/src/components/BroadcastLayout.tsx
@@ -21,7 +21,7 @@ import { Board } from './Board';
 import type { CommentaryEntry } from '../commentary/commentaryQueue';
 import type { NarrationMove } from '../tts/audio-queue';
 import type { BoardAnnotations } from '../utils/board-annotations';
-import type { GameEvent } from '../engine/events';
+import type { PgnMove } from '../pgn/parser';
 
 interface BroadcastLayoutProps {
   gameState: GameState;
@@ -55,44 +55,46 @@ interface BroadcastLayoutProps {
   narrationAnnotations?: BoardAnnotations;
   /** Move arrows for the currently-narrated move. */
   narrationArrows: NarrationMove[];
+  /**
+   * Parsed PGN moves indexed by ply, supplied by BroadcastView. The
+   * authoritative source for `fen` / `from` / `to` per ply, regardless
+   * of how the runtime's eventLog is populated (in replay mode the
+   * eventLog only covers replayed moves, NOT priorMoveHistory, so
+   * looking up FENs by eventLog index is incorrect).
+   */
+  pgnMoves: PgnMove[];
 }
 
 /**
  * Resolve the move whose narration is currently playing. When
- * narrationMoveIndex >= 0, the displayed board should reflect the
- * position AFTER that ply — even if the runtime has already advanced
- * to a later move.
+ * narrationMoveIndex >= 0, the displayed board reflects the position
+ * AFTER that ply — even if the runtime has already advanced.
+ *
+ * Looks up FEN + from + to directly from the parsed PGN moves array,
+ * which has correct per-ply data regardless of replay vs live mode.
+ * (The runtime's eventLog only stores MoveApplied for replay moves,
+ * not for priorMoveHistory, so eventLog-by-index lookups break for
+ * short captures that fast-forward past a startPly.)
  */
 function narratedMoveInfo(
   gameState: GameState,
   narrationMoveIndex: number,
+  pgnMoves: PgnMove[],
 ): { san: string; turnNumber: number; color: 'w' | 'b'; fen: string; from?: string; to?: string } | null {
-  const idx = narrationMoveIndex >= 0
-    ? Math.min(narrationMoveIndex, gameState.moveHistory.length - 1)
-    : gameState.moveHistory.length - 1;
-  if (idx < 0) return null;
+  const cap = Math.min(gameState.moveHistory.length - 1, pgnMoves.length - 1);
+  if (cap < 0) return null;
+  const idx = narrationMoveIndex >= 0 ? Math.min(narrationMoveIndex, cap) : cap;
   const move = gameState.moveHistory[idx];
-  if (!move) return null;
-  // Find the MoveApplied event for this ply to recover its FEN +
-  // from/to. The eventLog stores them in order; the Nth MoveApplied
-  // corresponds to move index N.
-  let seen = 0;
-  for (const event of gameState.eventLog) {
-    if (event.type !== 'MoveApplied') continue;
-    if (seen === idx) {
-      const ev = event as Extract<GameEvent, { type: 'MoveApplied' }>;
-      return {
-        san: move.move,
-        turnNumber: move.turnNumber,
-        color: move.color,
-        fen: ev.payload.fen,
-        from: ev.payload.from,
-        to: ev.payload.to,
-      };
-    }
-    seen++;
-  }
-  return { san: move.move, turnNumber: move.turnNumber, color: move.color, fen: gameState.fen };
+  const pgnMove = pgnMoves[idx];
+  if (!move || !pgnMove) return null;
+  return {
+    san: move.move,
+    turnNumber: move.turnNumber,
+    color: move.color,
+    fen: pgnMove.fen,
+    from: pgnMove.from,
+    to: pgnMove.to,
+  };
 }
 
 export function BroadcastLayout({
@@ -108,6 +110,7 @@ export function BroadcastLayout({
   narrationSquares,
   narrationAnnotations,
   narrationArrows,
+  pgnMoves,
 }: BroadcastLayoutProps) {
   // The displayed board tracks the narrated move, not the runtime's
   // latest. When narrationMoveIndex is -1 (no narration yet), fall
@@ -116,7 +119,7 @@ export function BroadcastLayout({
   // panel in sync (we don't list moves the narrator hasn't reached).
   const effectiveMoveIndex = narrationMoveIndex >= 0 ? narrationMoveIndex : gameState.moveHistory.length - 1;
   const displayedMoveHistory = gameState.moveHistory.slice(0, Math.max(0, effectiveMoveIndex + 1));
-  const narratedInfo = narratedMoveInfo(gameState, narrationMoveIndex);
+  const narratedInfo = narratedMoveInfo(gameState, narrationMoveIndex, pgnMoves);
   const displayedFen = narratedInfo?.fen ?? gameState.fen;
   const displayedLastMove =
     narratedInfo && narratedInfo.from && narratedInfo.to

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -8,6 +8,7 @@ import { TournamentProgress } from './TournamentProgress';
 import { BroadcastLayout } from './BroadcastLayout';
 import { getActiveAudioNarrationQueue, runWhenAudioNarrationQueueAvailable, type NarrationMove } from '../tts/audio-queue';
 import { createRenderPlanFromPgn, type RenderPlan } from '../production/renderPlan';
+import { parseSinglePgn } from '../pgn/parser';
 import type { BoardAnnotations } from '../utils/board-annotations';
 
 /**
@@ -44,6 +45,19 @@ export function BroadcastView() {
   const [loadError] = useState<string | null>(() => resolvePgnSource(config).error);
   const [historicalContext] = useState<string | undefined>(() => resolvePgnSource(config).historicalContext);
   const [episodeCommentatorModel] = useState<string | null>(() => resolvePgnSource(config).commentatorModel);
+  // Pre-parsed PGN moves. BroadcastLayout uses these to look up per-ply
+  // FEN / from / to, because the runtime's eventLog only contains
+  // MoveApplied events for moves the replay actually emits — not the
+  // priorMoveHistory it fast-forwards through for short captures.
+  const [pgnMoves] = useState<import('../pgn/parser').PgnMove[]>(() => {
+    try {
+      const source = resolvePgnSource(config).pgnText;
+      if (!source) return [];
+      return parseSinglePgn(source).moves;
+    } catch {
+      return [];
+    }
+  });
   // Phase 4: resolve a short's ply range when ?shortId= is set. null
   // means "play the full game" (full-episode capture).
   const [shortRange] = useState<{ startPly: number; endPly: number; clipId: string } | null>(
@@ -335,6 +349,7 @@ export function BroadcastView() {
         narrationSquares={narrationSquares}
         narrationAnnotations={narrationAnnotations}
         narrationArrows={narrationArrows}
+        pgnMoves={pgnMoves}
       />
     </>
   );


### PR DESCRIPTION
## Summary

User report after PR #49: the board still races ahead of the caption near the queen sacrifice transition (e.g. title "Move 16 · Qb8+" but board shows position after Nxb8).

### Root cause

`narratedMoveInfo()` in `BroadcastLayout` counted `MoveApplied` events in `eventLog` and treated the Nth `MoveApplied` as `moveHistory[N]`. That assumption holds in live games. It breaks in replay-with-`startPly` mode: `priorMoveHistory` entries are in `moveHistory` but NOT in `eventLog` (the runtime fast-forwards through them without emitting events).

For a short capture starting at ply 24, looking up `moveHistory[30]` tried to find the 31st `MoveApplied` — which doesn't exist (only 7 replay events emitted by then) — and fell through to the `gameState.fen` fallback, which reflects the LATEST applied position, **one ply ahead of the narrated move**.

### Fix

Parse the PGN once at `BroadcastView` mount, pass the resulting `PgnMove[]` (which already carries per-ply `fen` + `from` + `to`) into `BroadcastLayout`. `narratedMoveInfo` looks up `pgnMoves[narrationMoveIndex]` directly — correct regardless of `priorMoveHistory` or `eventLog` state.

### Verified

**Frame t=150s** — Title "Move 15… · Nxd7"
- Board: knight on d7 (yellow circle), purple from-square f6, yellow annotations on b8/d8 from the model
- Caption: "But the knight on d7 is now overloaded — it must guard b8 and help cover d8 — and Morphy's famous Qb8+ is about to expose that fatal geometry."

**Frame t=170s** — Title "Move 16 · Qb8+"
- Board: **queen on b8 (just played)**, purple from-square b3, yellow circles on queen + king
- Caption: "If Black takes, Rd8# ends it at once — the rook on d1 owns the file, the king on e8 has no flight…"

Board + title + caption + annotations now align at every sampled frame.

### Test plan

- [x] `npm run build` clean
- [x] `npm run export:game -- --episode opera_game_morphy_1858 --short=opera_game_combination --fast` produces 271s capture, 188s tight
- [x] Frame extraction at t=150s and t=170s confirms sync across the previously-broken Qb8+/Nxb8 transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)
