### PR TITLE
feat(mp4-export): lesson mode — first-person teacher commentator (AI Teaches the Italian Game)

### DIFF
--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -44,6 +44,7 @@ export function BroadcastView() {
   const [pgnText] = useState<string | null>(() => resolvePgnSource(config).pgnText);
   const [loadError] = useState<string | null>(() => resolvePgnSource(config).error);
   const [historicalContext] = useState<string | undefined>(() => resolvePgnSource(config).historicalContext);
+  const [lessonContext] = useState<string | undefined>(() => resolvePgnSource(config).lessonContext);
   const [episodeCommentatorModel] = useState<string | null>(() => resolvePgnSource(config).commentatorModel);
   // Pre-parsed PGN moves. BroadcastLayout uses these to look up per-ply
   // FEN / from / to, because the runtime's eventLog only contains
@@ -203,6 +204,7 @@ export function BroadcastView() {
 
         startReplay(pgnText, {
           historicalContext,
+          lessonContext,
           // Broadcast mode: each move waits on commentary + narration
           // before the next fires (paceWithNarration). A small
           // moveDelayMs gives the FIRST move's commentary time to
@@ -226,7 +228,7 @@ export function BroadcastView() {
         if (replayMode) stopReplay();
       },
     });
-  }, [pgnText, historicalContext, startReplay, stopReplay, replayMode, shortRange?.startPly]);
+  }, [pgnText, historicalContext, lessonContext, startReplay, stopReplay, replayMode, shortRange?.startPly]);
 
   useEffect(() => {
     exportBridge.__markReplayReady(Boolean(pgnText) && !loadError);
@@ -409,6 +411,8 @@ interface ResolvedPgnSource {
   pgnText: string | null;
   error: string | null;
   historicalContext: string | undefined;
+  /** Teacher-voice prompt for lessons. Mutually exclusive with historicalContext. */
+  lessonContext: string | undefined;
   commentatorModel: string | null;
   /** When ?shortId= matches an authored clip, its ply range. Else null. */
   shortRange: { startPly: number; endPly: number; clipId: string } | null;
@@ -425,6 +429,7 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
       pgnText: config.rawPgn,
       error: null,
       historicalContext: undefined,
+      lessonContext: undefined,
       commentatorModel: null,
       shortRange: null,
     };
@@ -435,6 +440,7 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
       pgnText: null,
       error: 'No episode id supplied and no default episode is registered.',
       historicalContext: undefined,
+      lessonContext: undefined,
       commentatorModel: null,
       shortRange: null,
     };
@@ -445,6 +451,7 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
       pgnText: null,
       error: `Unknown episode id "${episodeId}". Check src/episodes/registry.ts.`,
       historicalContext: undefined,
+      lessonContext: undefined,
       commentatorModel: null,
       shortRange: null,
     };
@@ -459,6 +466,7 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
           episode.exports?.shorts.map((s) => s.id).join(', ') ?? '(none)'
         }`,
         historicalContext: episode.historicalContext,
+        lessonContext: episode.commentator.lessonContext,
         commentatorModel: episode.commentator.model,
         shortRange: null,
       };
@@ -473,6 +481,7 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
     pgnText: episode.pgn,
     error: null,
     historicalContext: episode.historicalContext,
+    lessonContext: episode.commentator.lessonContext,
     commentatorModel: episode.commentator.model,
     shortRange,
   };

--- a/src/components/TournamentProgress.tsx
+++ b/src/components/TournamentProgress.tsx
@@ -11,7 +11,7 @@ import { downloadSingleGamePGN } from '../utils/export';
 import { downloadSingleGameJSON } from '../utils/export';
 import { CommentaryQueue, type CommentaryEntry } from '../commentary/commentaryQueue';
 import { createLLMClient } from '../llm/client';
-import { getHistoricalCommentatorPrompt, buildPuzzleBreakIntroPrompt, buildPuzzleSetupPromptWithOracle, buildPuzzleCommentaryTurnPromptWithOracle, buildPuzzleOutroPromptWithOracle } from '../llm/prompts';
+import { getHistoricalCommentatorPrompt, getLessonCommentatorPrompt, buildPuzzleBreakIntroPrompt, buildPuzzleSetupPromptWithOracle, buildPuzzleCommentaryTurnPromptWithOracle, buildPuzzleOutroPromptWithOracle } from '../llm/prompts';
 import { runResilientTextGeneration } from '../llm/resilient-text';
 import { fetchLichessPuzzle, getPuzzleFamilyId, prefillPuzzlePool, type LichessPuzzle, type PuzzleTurn } from '../commentary/puzzleBreak';
 import { parseAnnotations, EMPTY_ANNOTATIONS, parsePuzzleMoves, hasAnnotations, mergeAnnotations, type BoardAnnotations } from '../utils/board-annotations';
@@ -324,21 +324,27 @@ export function TournamentProgress() {
     };
   }, [getClient, getCommentatorModelCb]);
 
-  // Wire historical prompt and move-by-move narration for replay mode
+  // Wire historical / lesson prompt and move-by-move narration for
+  // replay mode. lessonContext wins over historicalContext when both
+  // are present (lessons frame the AI as the player-teacher; the
+  // historical-game framing is incompatible with that voice).
   const replayHistoricalContext = useTournamentStore(s => s.replayHistoricalContext);
+  const replayLessonContext = useTournamentStore(s => s.replayLessonContext);
   useEffect(() => {
     if (!replayMode || !activeRuntime) return;
     if (queueRef.current) {
-      // Replay: move-by-move commentary (batch size 1) + optional historical prompt
       queueRef.current.setMaxBatchSize(1);
-      // Use model.maxTokens if set (controlled by Tokens dropdown), otherwise default to 16k.
-      // No dead-air constraint in replay — we want rich commentary.
       queueRef.current.setMaxTokensOverride(commentatorModel?.maxTokens ?? 16000);
-      if (replayHistoricalContext) {
-        const ttsMode = useSettingsStore.getState().ttsEnabled;
-        const verbosity = commentatorModel?.verbosity;
-        const prompt = getHistoricalCommentatorPrompt(replayHistoricalContext, ttsMode, verbosity);
-        queueRef.current.setSystemPromptOverride(prompt);
+      const ttsMode = useSettingsStore.getState().ttsEnabled;
+      const verbosity = commentatorModel?.verbosity;
+      if (replayLessonContext) {
+        queueRef.current.setSystemPromptOverride(
+          getLessonCommentatorPrompt(replayLessonContext, ttsMode, verbosity),
+        );
+      } else if (replayHistoricalContext) {
+        queueRef.current.setSystemPromptOverride(
+          getHistoricalCommentatorPrompt(replayHistoricalContext, ttsMode, verbosity),
+        );
       }
     }
     return () => {
@@ -346,7 +352,7 @@ export function TournamentProgress() {
       queueRef.current?.setMaxTokensOverride(undefined);
       queueRef.current?.setSystemPromptOverride(undefined);
     };
-  }, [replayMode, activeRuntime, replayHistoricalContext, commentatorModel?.verbosity, commentatorModel?.maxTokens]);
+  }, [replayMode, activeRuntime, replayHistoricalContext, replayLessonContext, commentatorModel?.verbosity, commentatorModel?.maxTokens]);
 
   // Reset queue on new game — identical for tournament + replay
   useEffect(() => {

--- a/src/episodes/index.ts
+++ b/src/episodes/index.ts
@@ -16,3 +16,4 @@ export {
   listEpisodesBySource,
 } from './registry';
 export { OPERA_GAME_EPISODE } from './opera_game_morphy_1858';
+export { ITALIAN_GAME_LESSON_EPISODE } from './italian_game_lesson';

--- a/src/episodes/italian_game_lesson/commentator.ts
+++ b/src/episodes/italian_game_lesson/commentator.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_COMMENTATOR, type EpisodeCommentatorConfig } from '../types';
+
+/**
+ * Commentator config for the Italian Game lesson.
+ *
+ * Uses the channel-default voice. The `lessonContext` field switches
+ * the commentator into TEACHER mode (first-person, "I'm playing X
+ * because Y") via getLessonCommentatorPrompt — distinct from the
+ * historical-narrator framing used by Opera Game.
+ *
+ * The persona text below is read into the system prompt. Keep it
+ * focused on the lesson topic; don't reference players, results, or
+ * "the game" — there is no historical match here.
+ */
+export const ITALIAN_GAME_LESSON_COMMENTATOR: EpisodeCommentatorConfig = {
+  ...DEFAULT_COMMENTATOR,
+  lessonContext: [
+    'Lesson topic: the Italian Game (Giuoco Piano main line).',
+    'You are an AI teacher demonstrating the opening to a chess student who knows the rules but is new to opening theory.',
+    'Each move on the board is YOUR move — you are playing both sides of the demonstration to show typical play from each side. Speak in first person: "I am playing e4 to claim the center", "Now I switch to the Black side and play e5 to contest it".',
+    'For each move, explain in 1-2 sentences: the IDEA (what the move accomplishes), and one teaching point (a principle, a common student mistake, or a typical follow-up plan).',
+    'Cover these themes naturally as they come up: central control, the order of piece development (knights before bishops), the value of an active bishop diagonal (Bc4/Bc5 eyeing f7/f2), early castling, the c3-d4 break, the Nbd2-Nf1-Ng3 maneuver, trades that improve pawn structure.',
+    'Tone: friendly and concrete. Avoid jargon when a plain word works. Do NOT reference an audience, a video, "the lesson", or "the result" — just teach the moves.',
+  ].join(' '),
+};

--- a/src/episodes/italian_game_lesson/index.ts
+++ b/src/episodes/italian_game_lesson/index.ts
@@ -1,0 +1,29 @@
+import type { Episode } from '../types';
+import { ITALIAN_GAME_LESSON_PGN } from './pgn';
+import { ITALIAN_GAME_LESSON_COMMENTATOR } from './commentator';
+
+/**
+ * The Italian Game — opening lesson.
+ *
+ * The PGN is a curated 12-move teaching line through the Giuoco Piano
+ * main line. The commentator is in TEACHER mode (first-person voice,
+ * lessonContext set), making this the first "AI teaches X opening"
+ * style episode in the catalog.
+ *
+ * source = 'agent_generated' rather than 'public_domain' or
+ * 'licensed' because this isn't a historical game — it's an AI demo.
+ */
+export const ITALIAN_GAME_LESSON_EPISODE: Episode = {
+  id: 'italian_game_lesson',
+  title: 'AI Teaches the Italian Game',
+  summary:
+    'An AI walks through the Italian Game (Giuoco Piano main line), playing both sides of a 12-move demonstration and explaining each idea in real time.',
+  source: 'agent_generated',
+  pgn: ITALIAN_GAME_LESSON_PGN,
+  commentator: ITALIAN_GAME_LESSON_COMMENTATOR,
+};
+
+export {
+  ITALIAN_GAME_LESSON_PGN,
+  ITALIAN_GAME_LESSON_COMMENTATOR,
+};

--- a/src/episodes/italian_game_lesson/pgn.ts
+++ b/src/episodes/italian_game_lesson/pgn.ts
@@ -1,0 +1,28 @@
+/**
+ * The Italian Game — Giuoco Piano main line.
+ *
+ * 12-move teaching line covering the classical Italian setup through
+ * a typical kingside fianchetto-style middlegame plan. Selected to
+ * showcase:
+ *   - Central pawn play (e4 / e5, d2-d3)
+ *   - Piece development priorities (knight before bishop, bishop to
+ *     active diagonal, castle early)
+ *   - The Italian's central tension (c3/d4 break vs. quiet d3 plans)
+ *   - Black's symmetric responses and where they break symmetry
+ *
+ * Game ends in a balanced middlegame position — this is an OPENING
+ * lesson, not a brilliancy. Move count is intentionally short
+ * (~3 minutes of capture wall-clock) so the demo runs fast.
+ */
+export const ITALIAN_GAME_LESSON_PGN = `[Event "AI Lesson — Italian Game"]
+[Site "—"]
+[Date "2026.05.21"]
+[Round "—"]
+[White "AI Teacher"]
+[Black "AI Teacher (Black side)"]
+[Result "*"]
+[ECO "C50"]
+[Opening "Italian Game"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. c3 Nf6 5. d3 d6 6. O-O O-O 7. Nbd2 a6 8. Bb3 Ba7 9. Re1 h6 10. Nf1 Be6 11. Bxe6 fxe6 12. Ng3 Qd7 *
+`;

--- a/src/episodes/registry.ts
+++ b/src/episodes/registry.ts
@@ -1,4 +1,5 @@
 import { OPERA_GAME_EPISODE } from './opera_game_morphy_1858';
+import { ITALIAN_GAME_LESSON_EPISODE } from './italian_game_lesson';
 import type { Episode, EpisodeSource } from './types';
 
 /**
@@ -9,6 +10,7 @@ import type { Episode, EpisodeSource } from './types';
  */
 export const CHESS_EPISODES: Episode[] = [
   OPERA_GAME_EPISODE,
+  ITALIAN_GAME_LESSON_EPISODE,
 ];
 
 /** Default episode id when no `?episode=` is specified. */

--- a/src/episodes/types.ts
+++ b/src/episodes/types.ts
@@ -38,6 +38,9 @@ export interface Episode {
    * Historical context injected into the commentator system prompt so it
    * has dates, tournament names, player background, and any quirks worth
    * narrating without having to recall them.
+   *
+   * Mutually exclusive with `commentator.lessonContext` — episodes that
+   * set the lesson context use the teacher prompt builder instead.
    */
   historicalContext?: string;
   /** Export configuration. Present once the episode is planned for export. */
@@ -80,6 +83,14 @@ export interface EpisodeCommentatorConfig {
    * the global commentator system prompt is not enough.
    */
   systemPromptAddition?: string;
+  /**
+   * Lesson context — when set, the commentator uses a TEACHER voice
+   * (first-person, "I'm playing X because Y") via
+   * getLessonCommentatorPrompt instead of the historical narrator voice.
+   * Use this for "AI teaches X opening" episodes. Mutually exclusive
+   * with the Episode-level historicalContext field.
+   */
+  lessonContext?: string;
 }
 
 /**

--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -492,6 +492,36 @@ function getCommentatorSystemPrompt(ttsMode?: boolean, verbosity?: string): stri
 }
 
 /**
+ * Build a commentary system prompt for a chess LESSON.
+ *
+ * Differs from the historical prompt in framing: instead of a retrospective
+ * narrator who knows the result, the LLM is positioned as a TEACHER
+ * walking through an opening / technique / pattern in first person.
+ * Each move is treated as a teaching beat — "I'm playing X because Y,
+ * the idea is Z, common student mistake is W." The lesson context
+ * carries the topic and the teacher persona.
+ *
+ * The PGN being played is still pre-determined (this is replay-mode
+ * lesson playback), but the prompt frames it as if the AI is choosing
+ * each move live as part of the lesson.
+ */
+export function getLessonCommentatorPrompt(lessonContext: string, ttsMode?: boolean, verbosity?: string): string {
+  const lessonPreamble = `You are an AI chess teacher giving a LESSON to a student audience. You are PLAYING the game while you explain — each move on the board is YOUR move (or, when it's the opponent's turn, you analyze what they played and why).
+
+LESSON CONTEXT:
+${lessonContext}
+
+Voice: first person, teacher to student. "I'm playing e4 because...", "Now I would expect Black to...", "The reason this move is so important is...".
+Do NOT reference "the game", "the players", or "the result" — there is no historical match here, this is a live demonstration.
+Focus on the IDEA behind each move, the pattern being taught, and the kinds of mistakes a learning player would make in similar positions.
+When the opponent plays, briefly explain what they did and how it affects your plan.
+
+`;
+  const verbDir = verbosity ? (VERBOSITY_DIRECTIVES[verbosity] || '') : '';
+  return lessonPreamble + COMMENTATOR_SYSTEM_PROMPT_BASE + (ttsMode ? COMMENTATOR_STYLE_TTS : COMMENTATOR_STYLE_RICH) + verbDir;
+}
+
+/**
  * Build a commentary system prompt for historical game replay.
  * Prepends historical context to the standard commentator prompt so the LLM
  * can foreshadow, build dramatic tension, and reference the game's significance.

--- a/src/store/tournamentStore.ts
+++ b/src/store/tournamentStore.ts
@@ -117,6 +117,8 @@ interface TournamentStore {
   replayPriorMoveCount: number;
   /** Historical context string for replay commentary prompt. */
   replayHistoricalContext: string | null;
+  /** Lesson framing for the commentator (teacher voice). Mutually exclusive with replayHistoricalContext. */
+  replayLessonContext: string | null;
   /** Commentator model for replay mode (independent of tournament config). */
   replayCommentatorModel: CommentatorConfig | null;
   setReplayCommentatorModel: (model: CommentatorConfig | null) => void;
@@ -150,7 +152,7 @@ interface TournamentStore {
   resumeGame: (matchIndex: number, pairIndex: number, slotIndex: 0 | 1) => void;
 
   // Replay actions
-  startReplay: (pgn: string, config: { historicalContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean }) => void;
+  startReplay: (pgn: string, config: { historicalContext?: string; lessonContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean }) => void;
   stopReplay: () => void;
 
   // Multi-tournament actions
@@ -204,6 +206,7 @@ export const useTournamentStore = create<TournamentStore>()(
       replayMode: false,
       replayPriorMoveCount: 0,
       replayHistoricalContext: null,
+      replayLessonContext: null,
       replayCommentatorModel: null,
       setReplayCommentatorModel: (model) => set({ replayCommentatorModel: model }),
       streamingText: '',
@@ -635,7 +638,7 @@ export const useTournamentStore = create<TournamentStore>()(
 
       // --- Replay actions ---
 
-      startReplay: (pgn: string, config: { historicalContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean }) => {
+      startReplay: (pgn: string, config: { historicalContext?: string; lessonContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean }) => {
         const { activeRuntime } = get();
         if (activeRuntime) {
           activeRuntime.abort('Starting replay');
@@ -756,6 +759,7 @@ export const useTournamentStore = create<TournamentStore>()(
           replayMode: true,
           replayPriorMoveCount: priorMoveHistory?.length ?? 0,
           replayHistoricalContext: config.historicalContext || null,
+          replayLessonContext: config.lessonContext || null,
           isRunning: true,
           isPaused: false,
           waitingForStart: false,


### PR DESCRIPTION
## Summary

Adds a parallel "lesson" framing alongside the historical-game framing. For an episode that sets `commentator.lessonContext`, the commentator LLM gets a teacher persona prompt — first person, "I'm playing X because Y", switching sides explicitly when teaching both colors.

This is the **script-and-persona** version of "AI teaches the Italian Game": the PGN is a curated opening line, but the voice is the AI walking through it as if playing live. A true "AI actually chooses the moves" variant is a bigger refactor (would fuse the player + the commentator into one LLM); this lesson-as-replay version ships today.

### What's added

- **`src/llm/prompts.ts`** — `getLessonCommentatorPrompt(lessonContext, ...)` builds a teacher-voice system prompt. Frames the LLM as a chess teacher playing both sides, first person, focused on the teaching idea behind each move. Explicitly tells it NOT to reference "the game", "the players", or "the result".
- **`src/store/tournamentStore.ts`** — `replayLessonContext` slot; `startReplay` accepts optional `lessonContext`. Mutually exclusive with `replayHistoricalContext`.
- **`src/components/TournamentProgress.tsx`** — lesson prompt wins over historical when both are set; falls back to the global default.
- **`src/episodes/types.ts`** — `EpisodeCommentatorConfig.lessonContext` field.
- **`src/components/BroadcastView.tsx`** — `resolvePgnSource` surfaces `episode.commentator.lessonContext`; bridge `start()` forwards it.
- **`src/episodes/italian_game_lesson/`** — first lesson episode. 12-move Giuoco Piano main line (1.e4 e5 2.Nf3 Nc6 3.Bc4 Bc5 4.c3 Nf6 5.d3 d6 6.O-O O-O 7.Nbd2 a6 8.Bb3 Ba7 9.Re1 h6 10.Nf1 Be6 11.Bxe6 fxe6 12.Ng3 Qd7). Teacher persona with focused themes (central control, development order, knight maneuver, structure). `source: 'agent_generated'`.

### Verified end-to-end

```
npm run export:game -- --episode italian_game_lesson --fast
```

- 24 plies of teacher narration, gpt-5.5 high reasoning + brief verbosity
- 11 min wall-clock capture → **7:42 tight MP4** after dead-air trim (200s removed across 50 silence ranges)

**Sample narration entries** (every entry was first-person teacher voice):
- cq-1: "Welcome. I'm going to play both sides of the Italian Game…"
- cq-3: "I'm playing e4 to claim central space and open lines for my…"
- cq-4: "Now I switch to the Black side and play e5, directly contest…"
- cq-13: "I'm playing O-O to get my king safe before I start the bigger…"
- cq-19: "I play Re1 to support the e4 pawn and prepare the central br…"

**Frame at t=150s** of the tight MP4:
- Title: "AI Teaches the Italian Game"
- Counter: "Move 3… · Bc5"
- Board: classical Italian (e4 e5 Nf3 Nc6 Bc4 Bc5), Bc5 just played
- Caption: "The teaching point is simple: after the knights come out, place bishops on useful lines and get ready to castle, instead of wasting time with early queen moves."

**Frame at t=350s:**
- Counter: "Move 9 · Re1"
- Board: Re1 just played, **e5 pawn highlighted yellow** (model annotation matching caption mention)
- Caption: "This rook also lines up on the e-file, so if the center opens, my pieces are already aimed at Black's e5 pawn and king-side structure."

### Output

```
exports/italian_game_lesson/italian_game_lesson.mp4         12.4 MB / 11:02
exports/italian_game_lesson/italian_game_lesson_tight.mp4    8.7 MB / 7:42
```

### Follow-ups

- **Live AI-as-player.** The LLM actually picks the moves AND narrates them in one combined call. Currently moves are predetermined (the PGN); the AI is teaching from a script. The "live" version requires fusing `GameRuntime`'s LLM-player path with the commentary pipeline so the player's `reasoning` field becomes the narration text.
- **More lesson episodes** — same scaffolding, just new Episode entries. Sicilian Najdorf, King's Indian, French Winawer, endgame fundamentals, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Italian Game lesson episode with educational commentary from a teacher perspective
  * Introduced lesson context support for alternative teacher-mode narration during replay

* **Refactor**
  * Updated replay system to prioritize lesson context over historical context for commentary generation
  * Enhanced commentary queue to support both lesson and historical framing modes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->