### PR TITLE
fix(mp4-export): hold board at starting position during intro (no more race-ahead)

### DIFF
--- a/src/components/BroadcastLayout.tsx
+++ b/src/components/BroadcastLayout.tsx
@@ -66,9 +66,14 @@ interface BroadcastLayoutProps {
 }
 
 /**
- * Resolve the move whose narration is currently playing. When
- * narrationMoveIndex >= 0, the displayed board reflects the position
- * AFTER that ply — even if the runtime has already advanced.
+ * Resolve the move whose narration is currently playing.
+ *
+ *  - narrationMoveIndex >= 0: return the parsed PGN ply at that index.
+ *    The displayed board reflects the position AFTER that ply.
+ *  - narrationMoveIndex == -1 (intro is playing, or no narration has
+ *    started yet): return null. The caller falls back to the STARTING
+ *    position from GameCreated.initialFen — not the runtime's latest
+ *    move, which has raced ahead during async intro generation.
  *
  * Looks up FEN + from + to directly from the parsed PGN moves array,
  * which has correct per-ply data regardless of replay vs live mode.
@@ -81,9 +86,10 @@ function narratedMoveInfo(
   narrationMoveIndex: number,
   pgnMoves: PgnMove[],
 ): { san: string; turnNumber: number; color: 'w' | 'b'; fen: string; from?: string; to?: string } | null {
+  if (narrationMoveIndex < 0) return null;
   const cap = Math.min(gameState.moveHistory.length - 1, pgnMoves.length - 1);
   if (cap < 0) return null;
-  const idx = narrationMoveIndex >= 0 ? Math.min(narrationMoveIndex, cap) : cap;
+  const idx = Math.min(narrationMoveIndex, cap);
   const move = gameState.moveHistory[idx];
   const pgnMove = pgnMoves[idx];
   if (!move || !pgnMove) return null;
@@ -95,6 +101,21 @@ function narratedMoveInfo(
     from: pgnMove.from,
     to: pgnMove.to,
   };
+}
+
+/**
+ * The position before any replay move has been narrated — i.e. what
+ * the viewer should see during the intro. Pulled from the GameCreated
+ * event's initialFen so it's correct for both full-game and
+ * short-with-startPly captures.
+ */
+function startingFenFor(gameState: GameState): string | null {
+  for (const event of gameState.eventLog) {
+    if (event.type === 'GameCreated') {
+      return event.payload.initialFen;
+    }
+  }
+  return null;
 }
 
 export function BroadcastLayout({
@@ -112,19 +133,26 @@ export function BroadcastLayout({
   narrationArrows,
   pgnMoves,
 }: BroadcastLayoutProps) {
-  // The displayed board tracks the narrated move, not the runtime's
-  // latest. When narrationMoveIndex is -1 (no narration yet), fall
-  // back to the latest applied move. Truncating the displayed move
-  // history to narrationMoveIndex+1 also keeps the "recent moves"
-  // panel in sync (we don't list moves the narrator hasn't reached).
-  const effectiveMoveIndex = narrationMoveIndex >= 0 ? narrationMoveIndex : gameState.moveHistory.length - 1;
-  const displayedMoveHistory = gameState.moveHistory.slice(0, Math.max(0, effectiveMoveIndex + 1));
+  // The displayed board tracks the NARRATED move, not the runtime's
+  // latest. During the intro (narrationMoveIndex < 0), the runtime
+  // can race ahead by several plies while the intro audio plays;
+  // showing the runtime's current position would put the board past
+  // moves the narrator hasn't reached. Fall back to the STARTING
+  // position from GameCreated.initialFen instead — both for the
+  // displayed FEN and for the recent-moves panel (empty during intro).
   const narratedInfo = narratedMoveInfo(gameState, narrationMoveIndex, pgnMoves);
-  const displayedFen = narratedInfo?.fen ?? gameState.fen;
+  const startingFen = startingFenFor(gameState);
+  const displayedFen = narratedInfo?.fen ?? startingFen ?? gameState.fen;
   const displayedLastMove =
     narratedInfo && narratedInfo.from && narratedInfo.to
       ? { from: narratedInfo.from, to: narratedInfo.to }
-      : lastMove;
+      : narratedInfo
+        ? lastMove
+        : undefined; // intro: no last-move highlight, the board is the opening position
+  const effectiveMoveIndex = narratedInfo ? narrationMoveIndex : -1;
+  const displayedMoveHistory = effectiveMoveIndex >= 0
+    ? gameState.moveHistory.slice(0, effectiveMoveIndex + 1)
+    : [];
 
   const recentMoves = useMemo(() => {
     // Last 6 plies of the DISPLAYED history (not the runtime's).
@@ -143,9 +171,11 @@ export function BroadcastLayout({
     return pairs;
   }, [displayedMoveHistory]);
 
+  // Neutral counter during intro (no specific move narrated yet) so
+  // the badge doesn't lie about which move the viewer is on.
   const moveCounterText = narratedInfo
     ? `Move ${narratedInfo.turnNumber}${narratedInfo.color === 'b' ? '…' : ''} · ${narratedInfo.san}`
-    : 'Move 1';
+    : 'Opening';
 
   // Eval bar percentage. Clamps centipawns to ±500 then maps to 0..100%
   // of white's lead. Mate is treated as the full bar.


### PR DESCRIPTION
## Summary

User report on the lesson MP4: at the start, the board was racing ahead during the intro narration. Specifically:
- **0:00:43** — "Move 1 · e4" caption matched the board (e4 played) ✓
- **0:00:45** — intro caption ("both sides will try to claim the center with e4 and e5…") but **board already showed e4 + e5 done** ✗
- Then when move 1 narration started, board **rewound** by a ply

### Root cause

The intro entry has no `maxMoveIndex`. My `narratedMoveInfo` treated `narrationMoveIndex == -1` as "fall back to the runtime's latest applied move." During async intro generation + playback (10–20s), the runtime had already fired moves 1 and 2 in the background — so the displayed board followed the runtime ahead. When move 1's audio actually started, `narrationMoveIndex` jumped to 0 and the board **re-wound** to position after e4.

### Fix

- `narratedMoveInfo` returns `null` for `narrationMoveIndex < 0` (no more runtime-latest fallback).
- New `startingFenFor(gameState)` helper pulls `initialFen` from the `GameCreated` event. Works for both full-game replays and short-with-startPly captures.
- `BroadcastLayout`'s `displayedFen` falls back to `startingFen` when no move is being narrated.
- `displayedLastMove` is `undefined` during intro (no stale last-move highlight on the starting position).
- `displayedMoveHistory` is empty during intro (recent-moves panel shows "No moves yet").
- `moveCounterText` says **"Opening"** during intro instead of lying with "Move 1".

### Verified

**Frame t=5s (intro):**
- Counter: "Opening"
- Board: **starting position**, no pieces moved
- Caption: "I'm going to demonstrate the Italian Game, showing the ideas for both White and Black as they appear on the board."
- Recent: "No moves yet"

**Frame t=40s (move 1):**
- Counter: "Move 1 · e4"
- Board: e4 just played (purple from-square e2, yellow annotation circles)
- Caption: "I am playing e4 to claim space in the center and open lines for my queen and bishop on f1…"
- Recent: "1. e4"

**No rewinds, no race-ahead.** Board only moves forward when the narrator actually reaches that move.

### Output

```
exports/italian_game_lesson/italian_game_lesson.mp4         11.4 MB / 10:20
exports/italian_game_lesson/italian_game_lesson_tight.mp4    7.8 MB /  6:56
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
