### PR TITLE
feat(mp4-export): standardized Oracle Trust Calibration intro + outro

### DIFF
--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -31,6 +31,12 @@ export function BroadcastView() {
   const stopReplay = useTournamentStore(s => s.stopReplay);
   const activeGameState = useTournamentStore(s => s.activeGameState);
   const replayMode = useTournamentStore(s => s.replayMode);
+  // The store's post-game .then() block (recap → broadcast outro →
+  // narration drain) only flips isRunning to false at the very end.
+  // Waiting on it — not just terminal game status — is what keeps
+  // finalizeRecording from stopping the MediaRecorder before the
+  // outro audio is enqueued and played.
+  const isRunning = useTournamentStore(s => s.isRunning);
   const setReplayCommentatorModel = useTournamentStore(s => s.setReplayCommentatorModel);
   const ttsEnabled = useSettingsStore(s => s.ttsEnabled);
   // Subscribed via hook so changes trigger BroadcastLayout re-renders.
@@ -263,7 +269,12 @@ export function BroadcastView() {
     const status = activeGameState.status;
     const isTerminal = status !== 'created' && status !== 'in_progress';
     const shortDone = shortRange && activeGameState.moveHistory.length >= shortRange.endPly + 1;
-    if (!isTerminal && !shortDone) return;
+    // Wait for BOTH terminal status AND isRunning=false. The store
+    // flips isRunning at the end of its post-game .then() block,
+    // AFTER recap + broadcast outro have been generated and the
+    // narration queue has drained. Without that gate, this effect
+    // would stop the MediaRecorder before the outro audio plays.
+    if ((!isTerminal && !shortDone) || isRunning) return;
 
     // Once-only: the effect re-runs on every game state change, but
     // we want to flip ended (and stop the recorder) exactly once.
@@ -274,7 +285,7 @@ export function BroadcastView() {
       exportBridge.__markEnded();
       if (shortDone && !isTerminal) stopReplay();
     });
-  }, [activeGameState, shortRange, stopReplay]);
+  }, [activeGameState, shortRange, stopReplay, isRunning]);
 
   if (loadError) {
     return (

--- a/src/components/TournamentProgress.tsx
+++ b/src/components/TournamentProgress.tsx
@@ -11,7 +11,8 @@ import { downloadSingleGamePGN } from '../utils/export';
 import { downloadSingleGameJSON } from '../utils/export';
 import { CommentaryQueue, type CommentaryEntry } from '../commentary/commentaryQueue';
 import { createLLMClient } from '../llm/client';
-import { getHistoricalCommentatorPrompt, getLessonCommentatorPrompt, buildPuzzleBreakIntroPrompt, buildPuzzleSetupPromptWithOracle, buildPuzzleCommentaryTurnPromptWithOracle, buildPuzzleOutroPromptWithOracle } from '../llm/prompts';
+import { getHistoricalCommentatorPrompt, getLessonCommentatorPrompt, buildBroadcastIntroPrompt, buildPuzzleBreakIntroPrompt, buildPuzzleSetupPromptWithOracle, buildPuzzleCommentaryTurnPromptWithOracle, buildPuzzleOutroPromptWithOracle } from '../llm/prompts';
+import { isBroadcastMode } from '../app/broadcastConfig';
 import { runResilientTextGeneration } from '../llm/resilient-text';
 import { fetchLichessPuzzle, getPuzzleFamilyId, prefillPuzzlePool, type LichessPuzzle, type PuzzleTurn } from '../commentary/puzzleBreak';
 import { parseAnnotations, EMPTY_ANNOTATIONS, parsePuzzleMoves, hasAnnotations, mergeAnnotations, type BoardAnnotations } from '../utils/board-annotations';
@@ -464,7 +465,36 @@ export function TournamentProgress() {
           : null;
         let introPrompt: string;
         let boardSetupPrompt: string | null = null;
-        if (replayMode && replayHistoricalContext) {
+        // Broadcast mode (MP4 export): use the standardized Oracle
+        // Trust Calibration intro for every video — historical,
+        // lesson, or AI-vs-AI. This replaces the per-mode intro
+        // prompts below and ensures every export has consistent
+        // brand framing.
+        if (isBroadcastMode()) {
+          const broadcastTitle =
+            replayMode && activeGameState.white.displayName && activeGameState.black.displayName
+              ? `${activeGameState.white.displayName} vs ${activeGameState.black.displayName}`
+              : 'this match';
+          const kind: 'historical' | 'lesson' | 'match' = useTournamentStore.getState().replayLessonContext
+            ? 'lesson'
+            : replayMode && replayHistoricalContext
+              ? 'historical'
+              : 'match';
+          const episodeBlurb =
+            kind === 'lesson'
+              ? useTournamentStore.getState().replayLessonContext?.split('.')[0]
+              : kind === 'historical'
+                ? replayHistoricalContext?.split('.')[0]
+                : openingLabel ?? undefined;
+          introPrompt = buildBroadcastIntroPrompt({
+            title: broadcastTitle,
+            kind,
+            episodeBlurb: episodeBlurb || undefined,
+          });
+          // No separate boardSetupPrompt in broadcast mode — the
+          // standardized intro carries the format framing in one
+          // entry so the brand line stays tight.
+        } else if (replayMode && replayHistoricalContext) {
           // Historical replay with context
           introPrompt = `You are about to narrate a famous historical chess game. ${replayHistoricalContext}\n\nSet the stage for the audience in 2-3 sentences. Build anticipation.`;
           if (priorPly === 0) {

--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -521,6 +521,95 @@ When the opponent plays, briefly explain what they did and how it affects your p
   return lessonPreamble + COMMENTATOR_SYSTEM_PROMPT_BASE + (ttsMode ? COMMENTATOR_STYLE_TTS : COMMENTATOR_STYLE_RICH) + verbDir;
 }
 
+// ─── Broadcast intro / outro ────────────────────────────────────────
+//
+// Standardized framing applied to EVERY MP4 export, regardless of
+// episode kind (historical replay, lesson, AI-vs-AI match). The user
+// brand is the Mnemosyne Research Institute; the project's public-
+// facing name is Oracle Trust Calibration. Chess is the test bed
+// because every move is verifiable, every position is recoverable,
+// and the LLM cannot hide behind ambiguity.
+//
+// These prompt builders are called by TournamentProgress / startReplay
+// only when broadcastConfig.exportMode is true — normal SPA play
+// uses the existing per-mode intro prompts untouched.
+
+const BROADCAST_BRAND_BLURB = `Oracle Trust Calibration is a series from the Mnemosyne Research Institute that uses chess to benchmark how large language models behave under unreliable context — adversarial prompts, corrupted positions, conflicting feedback. Chess works as a test bed because every move is verifiable and every position is recoverable, so we can see exactly when and how an AI's grip on truth slips.`;
+
+export type BroadcastFormatKind = 'historical' | 'lesson' | 'match';
+
+interface BroadcastIntroSpec {
+  /** Episode / lesson / match title. */
+  title: string;
+  /** What kind of video this is — informs the format sentence. */
+  kind: BroadcastFormatKind;
+  /** One-sentence specific framing for this episode (e.g. "the Opera Game finishing combination"). */
+  episodeBlurb?: string;
+}
+
+/**
+ * Build the prompt that asks the commentator LLM to write the
+ * STANDARDIZED broadcast intro. Constraints:
+ *  - 3-5 sentences total
+ *  - Open with "Oracle Trust Calibration" / "Mnemosyne Research
+ *    Institute" framing (the brand)
+ *  - Name the format ("today's lesson", "this replay", "this match")
+ *  - Mention the specific game / topic
+ *  - Hand off to the body of the video naturally
+ *
+ * Keeps the rest of the per-move commentary prompts untouched —
+ * this only fires for the very first intro entry.
+ */
+export function buildBroadcastIntroPrompt(spec: BroadcastIntroSpec): string {
+  const formatSentence =
+    spec.kind === 'lesson'
+      ? `Today's lesson: ${spec.title}.${spec.episodeBlurb ? ` ${spec.episodeBlurb}.` : ''}`
+      : spec.kind === 'historical'
+        ? `This is a historical-game replay: ${spec.title}.${spec.episodeBlurb ? ` ${spec.episodeBlurb}.` : ''}`
+        : `This is an AI-vs-AI match: ${spec.title}.${spec.episodeBlurb ? ` ${spec.episodeBlurb}.` : ''}`;
+
+  return `Write the STANDARDIZED Oracle Trust Calibration intro for this video. Three to five sentences, spoken aloud, conversational.
+
+Required brand framing (re-state in your own words, do not quote verbatim):
+${BROADCAST_BRAND_BLURB}
+
+Required format framing:
+${formatSentence}
+
+End the intro by smoothly handing off to the body of the video (the first move / the demonstration / the match start). Do NOT use list formatting, headers, or markdown — this is spoken narration. Do NOT mention "the intro", "the video", or "the audience" — just deliver the content.`;
+}
+
+/**
+ * Build the prompt that asks the commentator LLM to write the
+ * STANDARDIZED broadcast outro. Constraints:
+ *  - 2-4 sentences
+ *  - Brief recap line ("That wraps the lesson on X" / "That's the
+ *    finish to Y") in the commentator's existing voice
+ *  - CTA to subscribe to the channel for more Oracle Trust
+ *    Calibration content
+ *  - Sign off naturally
+ *
+ * Does NOT spell out a URL — the YouTube channel link goes in the
+ * video description, not the spoken track. URLs sound robotic over
+ * TTS and break voice consistency.
+ */
+export function buildBroadcastOutroPrompt(spec: BroadcastIntroSpec): string {
+  const closer =
+    spec.kind === 'lesson'
+      ? `That wraps today's lesson on ${spec.title}.`
+      : spec.kind === 'historical'
+        ? `That's the finish to ${spec.title}.`
+        : `That's the match between the two AIs.`;
+
+  return `Write the STANDARDIZED Oracle Trust Calibration outro for this video. Two to four sentences, spoken aloud, in the same voice you've been using.
+
+1. Open with a clean closer like: ${closer}
+2. Add one sentence reflecting on what the video showed — what the viewer can take away (a pattern, an idea, an insight about how AI thinks under verifiable constraint).
+3. End with a subscribe CTA — invite the viewer to subscribe for more Oracle Trust Calibration content from the Mnemosyne Research Institute.
+
+Do NOT spell out a URL — the channel link is in the description. Do NOT use list formatting or markdown. Do NOT mention "the outro", "the video", or "the audience". Just deliver the content.`;
+}
+
 /**
  * Build a commentary system prompt for historical game replay.
  * Prepends historical context to the standard commentator prompt so the LLM

--- a/src/store/tournamentStore.ts
+++ b/src/store/tournamentStore.ts
@@ -33,6 +33,8 @@ import { useBenchmarkStore } from './benchmarkStore';
 import { getStockfishEval } from '../chess/stockfish';
 import type { LLMProviderConfig } from '../llm/client';
 import { createStreamingBridge } from './streamingBridge';
+import { isBroadcastMode } from '../app/broadcastConfig';
+import { buildBroadcastOutroPrompt } from '../llm/prompts';
 
 function autoName(config: GauntletTournamentConfig): string {
   const challenger = config.challenger.displayName || config.challenger.model;
@@ -806,6 +808,31 @@ export const useTournamentStore = create<TournamentStore>()(
               );
               if (_waitForNarration) await _waitForNarration();
             }
+
+            // Broadcast outro: standardized Oracle Trust Calibration
+            // sign-off + subscribe CTA. Fires for every MP4 export,
+            // regardless of whether the game completed naturally
+            // (lessons end at a chosen ply with no result; the recap
+            // above wouldn't run, but the outro still should).
+            if (_commentaryQueue && isBroadcastMode()) {
+              const lessonCtx = useTournamentStore.getState().replayLessonContext;
+              const histCtx = useTournamentStore.getState().replayHistoricalContext;
+              const kind: 'historical' | 'lesson' | 'match' = lessonCtx
+                ? 'lesson'
+                : histCtx
+                  ? 'historical'
+                  : 'match';
+              const broadcastTitle = replayState
+                ? `${replayState.white.displayName} vs ${replayState.black.displayName}`
+                : 'this match';
+              console.log('[Replay] Generating broadcast outro...');
+              await _commentaryQueue.generateIntro(
+                buildBroadcastOutroPrompt({ title: broadcastTitle, kind }),
+              );
+              if (_waitForNarration) await _waitForNarration();
+              console.log('[Replay] Outro complete.');
+            }
+
             set({
               activeRuntime: null,
               isRunning: false,


### PR DESCRIPTION
## Summary

- Every MP4 capture now opens with a brand intro and closes with a sign-off + YouTube subscribe CTA, regardless of episode type (lesson / historical / match).
- New shared `BROADCAST_BRAND_BLURB` introduces *Oracle Trust Calibration* (Mnemosyne Research Institute) — chess as a benchmark for how LLMs behave under unreliable context.
- Per-format framing lets the same scaffold work for openings lessons, historical replays, and live AI-vs-AI matches.
- Fixed an outro race: the recorder was stopping before the outro audio could be generated and played.

## Files

| File | Change |
|---|---|
| [src/llm/prompts.ts](src/llm/prompts.ts) | `buildBroadcastIntroPrompt` / `buildBroadcastOutroPrompt` + brand blurb constant |
| [src/components/TournamentProgress.tsx](src/components/TournamentProgress.tsx) | Broadcast-mode intro override (picks lesson/historical/match flavor) |
| [src/store/tournamentStore.ts](src/store/tournamentStore.ts) | Outro generation in post-game `.then()` after recap |
| [src/components/BroadcastView.tsx](src/components/BroadcastView.tsx) | Terminal effect waits for `isRunning === false`, not just terminal status |

## Why the race fix matters

The store's post-game `.then()` block runs: `waitUntilIdle → narration drain → recap → outro → narration drain → isRunning=false`. Without the new gate, `BroadcastView`'s terminal effect fired as soon as the runtime status flipped, stopping the MediaRecorder before the outro audio was ever enqueued.

## Smoke test (`italian_game_lesson`)

| Metric | pre-fix | post-fix |
|---|---|---|
| Frames captured | 20 038 | **23 808** |
| Capture duration | 667.9 s | **793.6 s** |
| Recorded audio | 7 048 KB | **8 596 KB** |
| Segment timings | 22 | **26** |
| Tight MP4 length | 7:16 | **9:34** |

Log confirms `[Replay] Generating broadcast outro... → cq-28: \"That wraps today's lesson…\" → [Replay] Outro complete.` — all before the recorder stops.

## Test plan

- [x] Smoke capture `italian_game_lesson` end-to-end; verify outro audio is in the MP4
- [ ] Capture a non-lesson episode to confirm the historical/match intro flavors render
- [ ] Manually audit two captured MP4s for tone consistency between intro and outro

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added standardized intro and outro messaging for broadcast videos with support for multiple content formats (historical, lesson, match)
  * Improved capture finalization to ensure tournament completion before triggering end-of-capture flow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->