### PR TITLE
feat(channel): track A/B standard + final-position + futures segment

### DIFF
--- a/src/commentary/commentaryQueue.ts
+++ b/src/commentary/commentaryQueue.ts
@@ -302,6 +302,8 @@ export class CommentaryQueue {
   private recentFillerTexts: string[] = [];
   /** True while the puzzle break panel is open — prevents double-firing on repeated audio drain callbacks. */
   private puzzleBreakActive = false;
+  /** Once true, no further filler or puzzle scheduling fires for this queue's lifetime. */
+  private fillerLockedOut = false;
   /** Snapshot of the last move for filler context. */
   private lastMoveSnapshot: QueuedMove | null = null;
   /** Timestamp when the last move snapshot was recorded (used to compute thinking elapsed time). */
@@ -958,8 +960,22 @@ Provide a post-game recap: summarize the key moments, turning points, and decisi
     this.fillerActive = false;
   }
 
+  /**
+   * One-way switch that disables ALL future filler/puzzle scheduling
+   * and cancels any in-flight filler. Called from the broadcast
+   * post-game sequence right before the futures + outro segments —
+   * once we're in "closing" mode, no stray filler clips should
+   * appear after the brand sign-off.
+   *
+   * Idempotent. Cannot be undone (re-create the queue instead).
+   */
+  lockOutFillers(): void {
+    this.fillerLockedOut = true;
+    this.cancelFiller();
+  }
+
   private scheduleFillerRecheck(ms: number): void {
-    if (this.destroyed || this.fillerTimer) return;
+    if (this.destroyed || this.fillerLockedOut || this.fillerTimer) return;
     this.fillerTimer = setTimeout(() => {
       this.fillerTimer = null;
       this.scheduleFillerIfIdle();
@@ -967,7 +983,7 @@ Provide a post-game recap: summarize the key moments, turning points, and decisi
   }
 
   private scheduleFillerIfIdle(): void {
-    if (this.destroyed) return;
+    if (this.destroyed || this.fillerLockedOut) return;
     if (this.pending.length > 0 || this.active !== null) return;
     if (!this.lastMoveSnapshot) return; // No game context yet
     if (this.puzzleBreakActive || (this.config.getPuzzleBreakActive?.() ?? false)) return; // Puzzle break already open
@@ -1010,7 +1026,7 @@ Provide a post-game recap: summarize the key moments, turning points, and decisi
   }
 
   private async runFiller(): Promise<void> {
-    if (this.destroyed || this.pending.length > 0 || this.active !== null) return;
+    if (this.destroyed || this.fillerLockedOut || this.pending.length > 0 || this.active !== null) return;
     if (this.fillerActive) return;
     if (this.puzzleBreakActive || (this.config.getPuzzleBreakActive?.() ?? false)) return;
 

--- a/src/episodes/italian_game_lesson/exports.ts
+++ b/src/episodes/italian_game_lesson/exports.ts
@@ -1,0 +1,23 @@
+import type { EpisodeExportConfig } from '../types';
+import { ITALIAN_GAME_VARIATIONS } from './variations';
+
+/**
+ * Export configuration for the Italian Game lesson.
+ *
+ * Track A model:
+ *   - The long-form is captured from the main PGN with the teacher voice.
+ *   - `shorts: []` — Track A does NOT slice the main video; instead each
+ *     line variation is captured as its own portrait Short with its own
+ *     PGN (`variations`). Pipeline wiring lives in scripts/export-chess-mp4.
+ *   - The long-form's "futures" segment teases the variation titles, so
+ *     the long-form and the Shorts work as a coherent content cluster.
+ */
+export const ITALIAN_GAME_EXPORT: EpisodeExportConfig = {
+  command: 'npm run export:game -- --episode italian_game_lesson',
+  outputRoot: 'exports',
+  descriptionCandidates: [
+    'An AI walks through the Italian Game (Giuoco Piano main line), playing both sides of a 12-move demonstration and explaining each idea in real time. Part of Oracle Trust Calibration — a research show using chess to benchmark how LLMs behave under unreliable context.',
+  ],
+  shorts: [],
+  variations: ITALIAN_GAME_VARIATIONS,
+};

--- a/src/episodes/italian_game_lesson/index.ts
+++ b/src/episodes/italian_game_lesson/index.ts
@@ -1,6 +1,8 @@
 import type { Episode } from '../types';
 import { ITALIAN_GAME_LESSON_PGN } from './pgn';
 import { ITALIAN_GAME_LESSON_COMMENTATOR } from './commentator';
+import { ITALIAN_GAME_VARIATIONS } from './variations';
+import { ITALIAN_GAME_EXPORT } from './exports';
 
 /**
  * The Italian Game — opening lesson.
@@ -15,15 +17,19 @@ import { ITALIAN_GAME_LESSON_COMMENTATOR } from './commentator';
  */
 export const ITALIAN_GAME_LESSON_EPISODE: Episode = {
   id: 'italian_game_lesson',
+  track: 'lesson',
   title: 'AI Teaches the Italian Game',
   summary:
     'An AI walks through the Italian Game (Giuoco Piano main line), playing both sides of a 12-move demonstration and explaining each idea in real time.',
   source: 'agent_generated',
   pgn: ITALIAN_GAME_LESSON_PGN,
   commentator: ITALIAN_GAME_LESSON_COMMENTATOR,
+  exports: ITALIAN_GAME_EXPORT,
 };
 
 export {
   ITALIAN_GAME_LESSON_PGN,
   ITALIAN_GAME_LESSON_COMMENTATOR,
+  ITALIAN_GAME_VARIATIONS,
+  ITALIAN_GAME_EXPORT,
 };

--- a/src/episodes/italian_game_lesson/variations.ts
+++ b/src/episodes/italian_game_lesson/variations.ts
@@ -1,0 +1,97 @@
+import type { VariationShort } from '../types';
+
+/**
+ * Line-variation Shorts that accompany the long-form Italian Game lesson.
+ *
+ * Each variation:
+ *   - Has its own self-contained PGN demonstrating ONE idea
+ *   - Carries its own teacher-voice lessonContext so the commentator
+ *     knows WHICH variation it's explaining (not just "the Italian Game")
+ *   - Targets 60–90s of portrait-format video
+ *
+ * The long-form lesson's "futures" segment names these four lines and
+ * teases the Shorts; viewers who want a specific variation tap through
+ * to the corresponding Short.
+ */
+export const ITALIAN_GAME_VARIATIONS: VariationShort[] = [
+  {
+    id: 'italian_two_knights_defense',
+    title: 'Italian Game: Two Knights Defense',
+    pgn: `[Event "Italian Game — Two Knights Defense"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. Ng5 d5 5. exd5 Na5 6. Bb5+ c6 7. dxc6 bxc6 8. Be2 h6 9. Nf3 e4 10. Ne5 Bd6 *
+`,
+    lessonContext:
+      "Two Knights Defense (3...Nf6). Black skips the symmetric 3...Bc5 and offers White the sharp 4.Ng5 attack on f7. The line shown is the main Berlin/Polerio defense (5...Na5) where Black gives up a pawn for active piece play and a powerful pawn duo on e-file. The point is to demonstrate that 3...Nf6 commits Black to tactical, not positional, chess. Highlight: 4.Ng5 is the only critical try; if White avoids it, Black equalizes with normal development.",
+    summary:
+      'The sharp alternative to the Giuoco Piano. Black plays 3...Nf6 and dares White to launch the 4.Ng5 attack — a 168-year-old theoretical battlefield.',
+    hook: 'What if Black skips 3...Bc5?',
+    durationTargetSec: 80,
+  },
+  {
+    id: 'italian_evans_gambit',
+    title: 'Italian Game: Evans Gambit',
+    pgn: `[Event "Italian Game — Evans Gambit"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. b4 Bxb4 5. c3 Ba5 6. d4 exd4 7. O-O d6 8. cxd4 Bb6 9. Nc3 Na5 10. Bg5 f6 11. Bf4 Ne7 *
+`,
+    lessonContext:
+      "Evans Gambit (4.b4!?). White sacrifices a wing pawn to seize the center with c3 + d4 and develop pieces faster than the Giuoco Pianissimo allows. Show how Black's accepted bishop is harried (5.c3 Ba5 6.d4) until White has built a classical pawn center and active queenside development. The teaching point: in pre-engine chess this was the main line of the Italian for 200 years because the initiative is worth a pawn — modern engines say Black is fine, but only with precise defense.",
+    summary:
+      "White sacrifices a pawn for fast development. Champion of the romantic era — 200 years of main-line Italian.",
+    hook: "Why give up a pawn on move 4?",
+    durationTargetSec: 75,
+  },
+  {
+    id: 'italian_moller_attack',
+    title: 'Italian Game: Möller Attack',
+    pgn: `[Event "Italian Game — Möller Attack"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. c3 Nf6 5. d4 exd4 6. cxd4 Bb4+ 7. Nc3 Nxe4 8. O-O Bxc3 9. d5 Bf6 10. Re1 Ne7 11. Rxe4 d6 *
+`,
+    lessonContext:
+      "Möller Attack — the d4 break instead of the modern quiet d3. After 5.d4 exd4 6.cxd4 Bb4+, White accepts an isolated d-pawn and sacrifices a pawn (8.O-O Bxc3 9.d5!) for a long-lasting attack on the kingside. Contrast directly with the quiet 5.d3 d6 system from the long-form lesson — same opening, completely different character. Teaching point: when to play d3 vs. d4 is the single most important choice in the Italian Game.",
+    summary:
+      'The aggressive d4 break — same opening as the long-form lesson, totally different character. White trades a pawn for attack.',
+    hook: 'What if White plays d4 instead of d3?',
+    durationTargetSec: 80,
+  },
+  {
+    id: 'italian_hungarian_defense',
+    title: 'Italian Game: Hungarian Defense',
+    pgn: `[Event "Italian Game — Hungarian Defense"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Be7 4. d4 exd4 5. Nxd4 d6 6. Nc3 Nf6 7. O-O O-O 8. h3 a6 9. Re1 Re8 10. Bf4 Bd7 *
+`,
+    lessonContext:
+      "Hungarian Defense (3...Be7). Black sidesteps the Italian entirely — no challenge to White's bishop on c4, no fight for the center. The point is to demonstrate the most solid (and most passive) reply to 3.Bc4: Black settles for a slightly worse but very hard-to-crack position. Compare to 3...Bc5 (Giuoco) and 3...Nf6 (Two Knights). Teaching point: this is the line you reach for when you want to neutralize without theory — Black accepts a small disadvantage in exchange for a position with no traps.",
+    summary:
+      'The boring-but-solid reply. Black declines to fight for the center and aims for a position with no traps and no theory.',
+    hook: 'How to neutralize the Italian without memorizing theory.',
+    durationTargetSec: 70,
+  },
+];

--- a/src/episodes/opera_game_morphy_1858/index.ts
+++ b/src/episodes/opera_game_morphy_1858/index.ts
@@ -6,6 +6,7 @@ import { OPERA_GAME_EXPORT } from './exports';
 
 export const OPERA_GAME_EPISODE: Episode = {
   id: 'opera_game_morphy_1858',
+  track: 'historical',
   title: 'The Opera Game — Morphy vs Brunswick and Isouard, 1858',
   summary:
     'Paul Morphy beats two consulting aristocrats in 17 moves at the Paris Opera, finishing with the queen sacrifice and rook mate that has been taught to chess students for the next 168 years.',

--- a/src/episodes/registry.ts
+++ b/src/episodes/registry.ts
@@ -28,3 +28,8 @@ export function getEpisode(id: string): Episode | undefined {
 export function listEpisodesBySource(source: EpisodeSource): Episode[] {
   return CHESS_EPISODES.filter((episode) => episode.source === source);
 }
+
+/** All episodes on a given content track. */
+export function listEpisodesByTrack(track: Episode['track']): Episode[] {
+  return CHESS_EPISODES.filter((episode) => episode.track === track);
+}

--- a/src/episodes/types.ts
+++ b/src/episodes/types.ts
@@ -24,6 +24,20 @@
 export interface Episode {
   /** Stable identifier (lowercase, underscored). Matches `exports/<id>/`. */
   id: string;
+  /**
+   * Content track. Drives the Shorts production model:
+   *  - 'lesson':     long-form "AI Teaches X" — Shorts are LINE VARIATIONS
+   *                  (each with its own self-contained PGN in
+   *                  `exports.variations`).
+   *  - 'historical': long-form "AI Reviews [game]" — Shorts are KEY MOMENTS
+   *                  sliced from the main PGN by move range
+   *                  (in `exports.shorts`).
+   *
+   * Both tracks share the Oracle Trust Calibration brand and the same
+   * intro/outro scaffold; only the body voice (teacher vs. historian)
+   * and the Shorts shape differ.
+   */
+  track: 'lesson' | 'historical';
   /** Display title used in the UI and on the published video. */
   title: string;
   /** One-paragraph summary for catalog views and the YouTube description. */
@@ -124,8 +138,48 @@ export interface EpisodeExportConfig {
   outputRoot: string;
   /** Candidate descriptions for the published video (YouTube etc.). */
   descriptionCandidates: string[];
-  /** Shorts to slice from the full video. */
+  /**
+   * Move-range clips of the main PGN. Used for Track B (historical) Shorts
+   * where a key moment from the long-form game becomes a 30–60s vertical clip.
+   * Empty for Track A lessons, which use `variations` instead.
+   */
   shorts: EpisodeShortClip[];
+  /**
+   * Line-variation Shorts for Track A (lesson) episodes. Each entry is a
+   * self-contained mini-lesson with its own PGN, lesson context, and
+   * commentator framing — NOT a slice of the main PGN. Captured as
+   * portrait MP4s alongside the long-form.
+   */
+  variations?: VariationShort[];
+}
+
+/**
+ * A line-variation Short for a Track A lesson. Unlike `EpisodeShortClip`
+ * (which slices the main PGN by move range), a variation has its OWN PGN
+ * showing an alternative continuation from a shared root position. The
+ * long-form lesson's "futures" segment tees up the variations; each
+ * variation Short delivers one of them as a 60–90s portrait clip.
+ */
+export interface VariationShort {
+  /** Stable id, namespaced under the parent episode (e.g. 'italian_evans_gambit'). */
+  id: string;
+  /** Display title (e.g. 'Italian Game: Evans Gambit'). */
+  title: string;
+  /** Full PGN of the variation, including headers. Self-contained. */
+  pgn: string;
+  /**
+   * Teacher-voice framing for this specific variation. Spliced into the
+   * lesson commentator prompt so the model knows what idea this line is
+   * demonstrating (e.g. "Evans Gambit — White sacrifices a pawn for
+   * rapid development and central control").
+   */
+  lessonContext: string;
+  /** One-line summary for the YouTube short description. */
+  summary: string;
+  /** Hook line for thumbnails / first sentence of narration. */
+  hook: string;
+  /** Target duration in seconds. Soft target, not enforced. */
+  durationTargetSec: number;
 }
 
 /** A published reference for an Episode (e.g. a YouTube upload). */

--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -610,6 +610,96 @@ export function buildBroadcastOutroPrompt(spec: BroadcastIntroSpec): string {
 Do NOT spell out a URL — the channel link is in the description. Do NOT use list formatting or markdown. Do NOT mention "the outro", "the video", or "the audience". Just deliver the content.`;
 }
 
+interface BroadcastFuturesSpec {
+  /** Episode / lesson / match title. */
+  title: string;
+  kind: BroadcastFormatKind;
+  /**
+   * Names of line-variation Shorts that accompany this lesson.
+   * Only set for Track A lessons; ignored for historical / match.
+   * The futures block name-checks these so viewers know what to
+   * watch next.
+   */
+  variationTitles?: string[];
+  /**
+   * For Track B (historical): a one-sentence pointer to what the
+   * game went on to influence or how the position fits into chess
+   * history. Used in place of variation tease.
+   */
+  historicalLegacyBlurb?: string;
+}
+
+/**
+ * Build the prompt for the FINAL POSITION + FUTURES segment that runs
+ * AFTER the last move's commentary and BEFORE the outro.
+ *
+ * Two job descriptions, picked by track:
+ *   - 'lesson':     Explain the final position in plain language (what
+ *                   each side has achieved, what the pawn structure
+ *                   says about the next 10 moves), then tee up the
+ *                   line-variation Shorts by name. This is the natural
+ *                   bridge to the Track A variation cluster.
+ *   - 'historical': Explain the final position and briefly say how the
+ *                   game's ideas echoed forward — what later players
+ *                   took from this, why the game survives in books.
+ *   - 'match':      Explain the final position and reflect on each
+ *                   model's decision-making patterns under verifiable
+ *                   constraint (no future tease).
+ *
+ * The outro that follows must be the LAST audio in the video, so this
+ * block has to be self-contained and end without a hand-off cue
+ * (no "and that brings us to..."). The store inserts the outro after
+ * narration of this block fully drains.
+ */
+export function buildBroadcastFuturesPrompt(spec: BroadcastFuturesSpec): string {
+  const positionTask = `Explain the FINAL POSITION on the board in plain language. What has each side actually achieved? What does the pawn structure suggest about the next phase of the game? Keep it concrete — name pieces and squares.`;
+
+  if (spec.kind === 'lesson') {
+    const variationLines = (spec.variationTitles ?? []).map((t) => `  • ${t}`).join('\n');
+    const teaseSection = spec.variationTitles && spec.variationTitles.length > 0
+      ? `Then tee up where the lesson goes next. From this position, the same opening branches into a handful of named variations — each one a different idea worth its own short video. Name them out loud (do not bullet-list, just speak them):
+${variationLines}
+Frame the variations as "if you want to see [name], that's its own short" — natural, conversational, NOT a sales pitch.`
+      : `Then tee up where the lesson goes next from this opening — what alternative lines a viewer might explore. Keep it natural and conversational.`;
+
+    return `Write the FINAL-POSITION + FUTURES segment for this Oracle Trust Calibration lesson. Four to six sentences, spoken aloud, in the same teacher voice you have been using.
+
+Part 1 — Final position:
+${positionTask}
+
+Part 2 — Futures:
+${teaseSection}
+
+Do NOT sign off here — the outro follows separately. Do NOT use markdown or list formatting. Do NOT mention "the video" or "the audience".`;
+  }
+
+  if (spec.kind === 'historical') {
+    const legacy = spec.historicalLegacyBlurb
+      ? `Then reflect briefly on how this game echoed forward. ${spec.historicalLegacyBlurb}`
+      : `Then reflect briefly on what later players took from this game and why it has survived in books.`;
+    return `Write the FINAL-POSITION + LEGACY segment for this Oracle Trust Calibration historical replay. Four to six sentences, in the same historian's voice you have been using.
+
+Part 1 — Final position:
+${positionTask}
+
+Part 2 — Legacy:
+${legacy}
+
+Do NOT sign off here — the outro follows separately. Do NOT use markdown or list formatting. Do NOT mention "the video" or "the audience".`;
+  }
+
+  // match
+  return `Write the FINAL-POSITION + REFLECTION segment for this Oracle Trust Calibration match. Four to six sentences, spoken aloud, in the same voice you have been using.
+
+Part 1 — Final position:
+${positionTask}
+
+Part 2 — Reflection:
+Reflect on what the two models' decisions showed about how they handle a verifiable, recoverable test bed. What did one model see that the other missed? What does that say about reasoning under unreliable context (the Oracle Trust Calibration angle)?
+
+Do NOT sign off here — the outro follows separately. Do NOT use markdown or list formatting. Do NOT mention "the video" or "the audience".`;
+}
+
 /**
  * Build a commentary system prompt for historical game replay.
  * Prepends historical context to the standard commentator prompt so the LLM

--- a/src/store/tournamentStore.ts
+++ b/src/store/tournamentStore.ts
@@ -33,8 +33,9 @@ import { useBenchmarkStore } from './benchmarkStore';
 import { getStockfishEval } from '../chess/stockfish';
 import type { LLMProviderConfig } from '../llm/client';
 import { createStreamingBridge } from './streamingBridge';
-import { isBroadcastMode } from '../app/broadcastConfig';
-import { buildBroadcastOutroPrompt } from '../llm/prompts';
+import { isBroadcastMode, getBroadcastConfig } from '../app/broadcastConfig';
+import { buildBroadcastOutroPrompt, buildBroadcastFuturesPrompt } from '../llm/prompts';
+import { getEpisode } from '../episodes';
 
 function autoName(config: GauntletTournamentConfig): string {
   const challenger = config.challenger.displayName || config.challenger.model;
@@ -809,12 +810,21 @@ export const useTournamentStore = create<TournamentStore>()(
               if (_waitForNarration) await _waitForNarration();
             }
 
-            // Broadcast outro: standardized Oracle Trust Calibration
-            // sign-off + subscribe CTA. Fires for every MP4 export,
-            // regardless of whether the game completed naturally
-            // (lessons end at a chosen ply with no result; the recap
-            // above wouldn't run, but the outro still should).
+            // Broadcast closing sequence (futures → outro). Standardized
+            // for every MP4 export, regardless of whether the game ended
+            // naturally — lessons end at a chosen ply with `*` and the
+            // recap above is skipped, but the closing sequence still
+            // fires.
+            //
+            // Order matters: the futures block explains the final
+            // position and tees up "what's next" (variation Shorts for
+            // lessons, legacy for historicals, reflection for matches);
+            // the outro is the LAST thing the viewer hears. Locking out
+            // fillers here keeps stray filler clips from generating
+            // between the outro and the recorder stopping.
             if (_commentaryQueue && isBroadcastMode()) {
+              _commentaryQueue.lockOutFillers();
+
               const lessonCtx = useTournamentStore.getState().replayLessonContext;
               const histCtx = useTournamentStore.getState().replayHistoricalContext;
               const kind: 'historical' | 'lesson' | 'match' = lessonCtx
@@ -825,6 +835,27 @@ export const useTournamentStore = create<TournamentStore>()(
               const broadcastTitle = replayState
                 ? `${replayState.white.displayName} vs ${replayState.black.displayName}`
                 : 'this match';
+
+              // Look up the episode by id (broadcast URL param) so we
+              // can pass variation titles to the futures prompt for
+              // lesson tracks. No-op for inline-PGN / unregistered ids.
+              const broadcastEpisodeId = getBroadcastConfig().episodeId;
+              const episode = broadcastEpisodeId ? getEpisode(broadcastEpisodeId) : undefined;
+              const variationTitles = kind === 'lesson'
+                ? (episode?.exports?.variations ?? []).map((v) => v.title)
+                : undefined;
+
+              console.log('[Replay] Generating final-position + futures...');
+              await _commentaryQueue.generateIntro(
+                buildBroadcastFuturesPrompt({
+                  title: broadcastTitle,
+                  kind,
+                  variationTitles,
+                }),
+              );
+              if (_waitForNarration) await _waitForNarration();
+              console.log('[Replay] Futures complete.');
+
               console.log('[Replay] Generating broadcast outro...');
               await _commentaryQueue.generateIntro(
                 buildBroadcastOutroPrompt({ title: broadcastTitle, kind }),


### PR DESCRIPTION
## Summary

Establishes the channel's content standard and the closing-sequence scaffold every Oracle Trust Calibration video now follows.

### Track A — Positional Analysis (\"AI Teaches X\")
- Long-form: 8–12 min lesson, first-person teacher voice.
- Shorts: **line variations** — each with its own self-contained PGN under `exports.variations`.

### Track B — Historical Analysis (\"AI Reviews [game]\")
- Long-form: 12–20 min replay, historian voice.
- Shorts: **key-moment clips** — sliced from the main PGN by move range under `exports.shorts`.

### Closing sequence (every broadcast capture)
\`body → final-position + futures → outro\`

- **Final-position + futures** ([prompts.ts](src/llm/prompts.ts) → \`buildBroadcastFuturesPrompt\`):
  - Lesson: explain the final position, then name-check the variation Shorts so the long-form bridges to the Short cluster.
  - Historical: explain the final position, then briefly note the game's legacy.
  - Match: explain the final position, then reflect on each model's reasoning under verifiable constraint.
- **Outro is now the LAST audio clip**. \`CommentaryQueue\` gains \`lockOutFillers()\` — called right before futures — which cancels in-flight fillers and blocks all future filler/puzzle scheduling. Closes the \`cq-29\` stray sign-off leak observed in [PR #53](https://github.com/Mnehmos/LLM-Chess/pull/53)'s capture.

## Schema

[\`src/episodes/types.ts\`](src/episodes/types.ts):
- \`Episode.track: 'lesson' | 'historical'\` — now required.
- \`EpisodeExportConfig.variations?: VariationShort[]\`
- New \`VariationShort\` with \`{ id, title, pgn, lessonContext, summary, hook, durationTargetSec }\`.

## Italian Game variation cluster

[\`src/episodes/italian_game_lesson/variations.ts\`](src/episodes/italian_game_lesson/variations.ts) — the channel's first variation cluster, four 60–90s Shorts:
1. **Two Knights Defense** (3...Nf6, 4.Ng5 sharp line)
2. **Evans Gambit** (4.b4!? — the romantic-era main line)
3. **Möller Attack** (the 5.d4 break — contrast with the quiet d3 lesson)
4. **Hungarian Defense** (3...Be7 — the boring-but-solid neutralizer)

Each has its own teacher-voice \`lessonContext\` so the commentator knows what idea it's demonstrating.

## Smoke test (\`italian_game_lesson\`)

| Marker | Result |
|---|---|
| cq-28 futures content | \`\"I'm stopping in a balanced Italian position: White has castl…\"\` |
| cq-29 outro content | \`\"That wraps today's lesson on AI Teacher vs AI Teacher (Black…\"\` |
| Clips after \`[Replay] Outro complete.\` | **0** |
| Tight MP4 length | 9:34 → **10:14** (futures segment included) |

## Follow-up

Pipeline wiring to capture each \`VariationShort\` as its own portrait MP4. Schema and content are in place — the next PR adds \`scripts/export-chess-mp4.ts\` support for \`--variation <id>\` and updates the broadcast bridge to accept a variation PGN.

## Test plan

- [x] Typecheck clean
- [x] Smoke capture: futures runs between body and outro
- [x] Smoke capture: outro is the last audio clip
- [ ] Capture a Track B episode to confirm the historical futures path
- [ ] Manual A/V audit of \`italian_game_lesson_tight.mp4\` for closing-sequence pacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)