### PR TITLE
feat(mp4-export): per-variation portrait Short capture pipeline

### DIFF
--- a/scripts/export-chess-mp4.ts
+++ b/scripts/export-chess-mp4.ts
@@ -10,6 +10,12 @@
  *   npm run export:game -- --episode <id> --preview=30
  *   npm run export:game -- --episode <id> --keep-frames
  *
+ * Shorts modes:
+ *   --short=<id1,id2>      authored move-range clips (Track B)
+ *   --all-shorts           every authored short (Track B)
+ *   --variation=<id1,id2>  line-variation Shorts (Track A) — portrait 1080x1920
+ *   --all-variations       every line-variation Short for the episode
+ *
  * TTS narration in the final MP4 (Phase 3.1):
  *   Configure via a gitignored `.env` at the repo root, or via env
  *   vars in your shell — env beats .env. See `.env.example` for the
@@ -40,7 +46,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ffmpegStatic from 'ffmpeg-static';
 import { CHESS_EPISODES, DEFAULT_EPISODE_ID, getEpisode } from '../src/episodes';
-import type { EpisodeShortClip } from '../src/episodes/types';
+import type { EpisodeShortClip, VariationShort } from '../src/episodes/types';
 import {
   createRenderPlanFromPgn,
   retimeRenderPlanWithSegmentTimings,
@@ -163,6 +169,10 @@ interface CliFlags {
   shortIds: string[];
   /** When true, capture every authored short (and skip full). */
   allShorts: boolean;
+  /** When set, capture only these specific variations (and skip full). */
+  variationIds: string[];
+  /** When true, capture every line-variation Short (and skip full). */
+  allVariations: boolean;
 }
 
 function parseFlags(argv: string[]): CliFlags {
@@ -175,6 +185,8 @@ function parseFlags(argv: string[]): CliFlags {
     outputRoot: 'exports',
     shortIds: [],
     allShorts: false,
+    variationIds: [],
+    allVariations: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -199,6 +211,14 @@ function parseFlags(argv: string[]): CliFlags {
       const value = arg.slice(arg.indexOf('=') + 1);
       if (value) flags.shortIds.push(...value.split(',').map((s) => s.trim()).filter(Boolean));
     }
+    else if (arg === '--all-variations') flags.allVariations = true;
+    else if (arg === '--variation' || arg === '--variations') {
+      const value = argv[i + 1];
+      if (value) flags.variationIds.push(...value.split(',').map((s) => s.trim()).filter(Boolean));
+    } else if (arg.startsWith('--variation=') || arg.startsWith('--variations=')) {
+      const value = arg.slice(arg.indexOf('=') + 1);
+      if (value) flags.variationIds.push(...value.split(',').map((s) => s.trim()).filter(Boolean));
+    }
   }
   return flags;
 }
@@ -210,6 +230,8 @@ interface ResolvedInput {
   episodeId?: string;
   /** Authored shorts available for this input. Empty for raw-PGN inputs. */
   authoredShorts: EpisodeShortClip[];
+  /** Line-variation Shorts available for this input. Empty for raw-PGN inputs. */
+  variations: VariationShort[];
 }
 
 async function resolveInput(flags: CliFlags): Promise<ResolvedInput> {
@@ -222,6 +244,7 @@ async function resolveInput(flags: CliFlags): Promise<ResolvedInput> {
       title: base,
       slug: base.toLowerCase().replace(/[^a-z0-9_-]+/g, '-'),
       authoredShorts: [],
+      variations: [],
     };
   }
   const id = flags.episodeId ?? DEFAULT_EPISODE_ID;
@@ -244,6 +267,7 @@ async function resolveInput(flags: CliFlags): Promise<ResolvedInput> {
     slug: episode.id,
     episodeId: episode.id,
     authoredShorts: episode.exports?.shorts ?? [],
+    variations: episode.exports?.variations ?? [],
   };
 }
 
@@ -286,6 +310,45 @@ function selectShorts(
   };
 }
 
+/**
+ * Filter the variations list according to CLI flags.
+ *
+ *   --all-variations          → include every variation, skip full
+ *   --variation=<id1,id2>     → include only the named variations, skip full
+ *   (neither)                 → no variations captured
+ *
+ * Returns `{ variations, skipFull }`. Throws on unknown variation ids.
+ */
+function selectVariations(
+  flags: CliFlags,
+  available: VariationShort[],
+): { variations: VariationShort[]; skipFull: boolean } {
+  if (!flags.allVariations && flags.variationIds.length === 0) {
+    return { variations: [], skipFull: false };
+  }
+  if (available.length === 0) {
+    throw new Error(
+      '--variation / --all-variations was requested but the resolved input has no variation shorts.',
+    );
+  }
+  if (flags.allVariations) {
+    return { variations: [...available], skipFull: true };
+  }
+  const known = new Map(available.map((v) => [v.id, v]));
+  const missing = flags.variationIds.filter((id) => !known.has(id));
+  if (missing.length > 0) {
+    throw new Error(
+      `--variation referenced unknown id(s): ${missing.join(', ')}. Available: ${[...known.keys()].join(
+        ', ',
+      )}`,
+    );
+  }
+  return {
+    variations: flags.variationIds.map((id) => known.get(id) as VariationShort),
+    skipFull: true,
+  };
+}
+
 async function main(): Promise<void> {
   const flags = parseFlags(process.argv.slice(2));
   const ffmpegPath = ffmpegStatic;
@@ -313,7 +376,11 @@ async function main(): Promise<void> {
   };
 
   // Phase 4: select shorts based on CLI flags.
-  const { shorts: selectedShorts, skipFull } = selectShorts(flags, input.authoredShorts);
+  const shortsSelection = selectShorts(flags, input.authoredShorts);
+  const variationsSelection = selectVariations(flags, input.variations);
+  const selectedShorts = shortsSelection.shorts;
+  const selectedVariations = variationsSelection.variations;
+  const skipFull = shortsSelection.skipFull || variationsSelection.skipFull;
 
   // Working dirs.
   const outDir = path.resolve(repoRoot, flags.outputRoot, slug);
@@ -325,8 +392,24 @@ async function main(): Promise<void> {
   );
   if (flags.fastMode) console.log('[export]   --fast (lower JPEG quality)');
   if (flags.previewDurationMs) console.log(`[export]   --preview=${flags.previewDurationMs / 1000} s`);
-  if (skipFull) console.log(`[export]   shorts mode: ${selectedShorts.map((s) => s.id).join(', ')}`);
-  else if (input.authoredShorts.length > 0) console.log(`[export]   ${input.authoredShorts.length} authored short(s) available (skipped; pass --all-shorts to include)`);
+  if (skipFull) {
+    const tags = [
+      ...selectedShorts.map((s) => `short:${s.id}`),
+      ...selectedVariations.map((v) => `variation:${v.id}`),
+    ];
+    console.log(`[export]   shorts mode: ${tags.join(', ')}`);
+  } else {
+    if (input.authoredShorts.length > 0) {
+      console.log(
+        `[export]   ${input.authoredShorts.length} authored short(s) available (skipped; pass --all-shorts to include)`,
+      );
+    }
+    if (input.variations.length > 0) {
+      console.log(
+        `[export]   ${input.variations.length} variation short(s) available (skipped; pass --all-variations to include)`,
+      );
+    }
+  }
 
   // Phase 3.1: resolve TTS config from env. Without TTS the capture
   // produces a silent MP4 and the replay speedruns (no narration gate
@@ -359,6 +442,19 @@ async function main(): Promise<void> {
     interface CaptureJob {
       label: string;
       shortId?: string;
+      variationId?: string;
+      /**
+       * Override PGN for this job (used by variation captures, whose
+       * PGN differs from the episode's main PGN). When set, the page
+       * is opened with ?pgn=... AND ?variationId=... — the inline PGN
+       * gives the SPA the moves to play immediately; the variationId
+       * lets BroadcastView pick up the parent episode's commentator
+       * config + the variation's own lessonContext + title.
+       *
+       * Actually no — easier path: pass episodeId + variationId, let
+       * BroadcastView resolve the variation's PGN from the registry.
+       * No inline PGN needed.
+       */
       viewport: { width: number; height: number; deviceScaleFactor?: number };
       outputPath: string;
     }
@@ -387,6 +483,24 @@ async function main(): Promise<void> {
         outputPath: path.resolve(repoRoot, shortTarget.outputPath),
       });
     }
+    for (const variation of selectedVariations) {
+      jobs.push({
+        label: `variation:${variation.id}`,
+        variationId: variation.id,
+        viewport: {
+          width: SHORTS_VIEWPORT.width,
+          height: SHORTS_VIEWPORT.height,
+          deviceScaleFactor: SHORTS_VIEWPORT.deviceScaleFactor,
+        },
+        outputPath: path.resolve(
+          repoRoot,
+          flags.outputRoot,
+          slug,
+          'variations',
+          `${variation.id}.mp4`,
+        ),
+      });
+    }
 
     const captures: Array<{
       job: CaptureJob;
@@ -408,12 +522,16 @@ async function main(): Promise<void> {
         `${slug}-${safeLabel}-${Date.now().toString(36)}`,
       );
       frameDirs.push(frameDir);
+      // Ensure the job's output directory exists. Variation jobs land
+      // in <slug>/variations/ which may not exist yet on first run.
+      await mkdir(path.dirname(job.outputPath), { recursive: true });
       console.log(`[export] capturing ${job.label} (${job.viewport.width}x${job.viewport.height})`);
       const capture = await recordBroadcastPlayback(browser, {
         serverUrl: server.url,
         episodeId: input.episodeId,
         rawPgn: input.episodeId ? undefined : input.pgnText,
         shortId: job.shortId,
+        variationId: job.variationId,
         frameDir,
         viewport: job.viewport,
         fastMode: flags.fastMode,
@@ -512,6 +630,7 @@ async function main(): Promise<void> {
           captures: captures.map((c) => ({
             label: c.job.label,
             shortId: c.job.shortId,
+            variationId: c.job.variationId,
             outputPath: path.relative(repoRoot, c.job.outputPath),
             tightOutputPath: c.tightOutputPath ? path.relative(repoRoot, c.tightOutputPath) : undefined,
             compressedRemovedS: c.compressedRemovedS,

--- a/scripts/lib/export/browserCapture.ts
+++ b/scripts/lib/export/browserCapture.ts
@@ -33,6 +33,13 @@ export interface CaptureOptions {
    * markEnded once the short's last ply has been played.
    */
   shortId?: string;
+  /**
+   * Variation id, passed as ?variationId=<id>. BroadcastView resolves
+   * the variation's own PGN + lessonContext + title for the capture;
+   * the parent episode supplies the commentator config. Used for
+   * Track A line-variation Shorts (portrait 1080x1920).
+   */
+  variationId?: string;
   /** Output frame dir (absolute path). Will be created. */
   frameDir: string;
   /** Viewport for the capture. */
@@ -308,6 +315,7 @@ function buildUrl(options: CaptureOptions): string {
   if (options.episodeId) url.searchParams.set('episode', options.episodeId);
   if (options.rawPgn) url.searchParams.set('pgn', options.rawPgn);
   if (options.shortId) url.searchParams.set('shortId', options.shortId);
+  if (options.variationId) url.searchParams.set('variationId', options.variationId);
   url.searchParams.set('w', String(options.viewport.width));
   url.searchParams.set('h', String(options.viewport.height));
   return url.toString();

--- a/src/app/broadcastConfig.ts
+++ b/src/app/broadcastConfig.ts
@@ -24,6 +24,15 @@ export interface BroadcastConfig {
    * range; ignored entirely in Phase 1.
    */
   shortId: string | null;
+  /**
+   * Optional variation id from ?variationId=<id>. Selects one of the
+   * parent episode's `exports.variations` entries — its self-contained
+   * PGN + lessonContext + title replace the long-form lesson for this
+   * capture, while the commentator model / voice come from the parent
+   * episode. Used to produce per-variation portrait Shorts on Track A.
+   * Mutually exclusive with shortId (which slices the main PGN).
+   */
+  variationId: string | null;
   /** Optional viewport width from ?w=<px>. Defaults to 1920. */
   viewportWidth: number | null;
   /** Optional viewport height from ?h=<px>. Defaults to 1080. */
@@ -51,6 +60,7 @@ function parse(): BroadcastConfig {
       episodeId: null,
       rawPgn: null,
       shortId: null,
+      variationId: null,
       viewportWidth: null,
       viewportHeight: null,
     };
@@ -62,6 +72,7 @@ function parse(): BroadcastConfig {
     episodeId: params.get('episode'),
     rawPgn: params.get('pgn'),
     shortId: params.get('shortId'),
+    variationId: params.get('variationId'),
     viewportWidth: parsePositiveInt(params, 'w'),
     viewportHeight: parsePositiveInt(params, 'h'),
   };

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -52,6 +52,8 @@ export function BroadcastView() {
   const [historicalContext] = useState<string | undefined>(() => resolvePgnSource(config).historicalContext);
   const [lessonContext] = useState<string | undefined>(() => resolvePgnSource(config).lessonContext);
   const [episodeCommentatorModel] = useState<string | null>(() => resolvePgnSource(config).commentatorModel);
+  const [titleOverride] = useState<string | undefined>(() => resolvePgnSource(config).titleOverride);
+  const [subtitleOverride] = useState<string | undefined>(() => resolvePgnSource(config).subtitleOverride);
   // Pre-parsed PGN moves. BroadcastLayout uses these to look up per-ply
   // FEN / from / to, because the runtime's eventLog only contains
   // MoveApplied events for moves the replay actually emits — not the
@@ -352,8 +354,8 @@ export function BroadcastView() {
         liveCommentaryText={activeNarrationText || streamingText || ''}
         commentaryEntries={commentaryEntries}
         stockfishEval={stockfishEval}
-        title={episode?.title ?? 'Chess Game'}
-        subtitle={episode?.summary?.split('.')[0]}
+        title={titleOverride ?? episode?.title ?? 'Chess Game'}
+        subtitle={subtitleOverride ?? episode?.summary?.split('.')[0]}
         orientation={
           (config.viewportHeight ?? 1080) > (config.viewportWidth ?? 1920) ? 'short' : 'full'
         }
@@ -427,12 +429,23 @@ interface ResolvedPgnSource {
   commentatorModel: string | null;
   /** When ?shortId= matches an authored clip, its ply range. Else null. */
   shortRange: { startPly: number; endPly: number; clipId: string } | null;
+  /** Override display title (used for variation captures). */
+  titleOverride?: string;
+  /** Override subtitle (used for variation captures). */
+  subtitleOverride?: string;
 }
 
 /**
  * Resolve a BroadcastConfig to a PGN source, historical context,
  * commentator model, and (Phase 4) authored-short ply range. Pure /
  * synchronous so it can run inside a useState initializer.
+ *
+ * Resolution precedence:
+ *   1. ?pgn=         raw inline PGN, no episode context
+ *   2. ?variationId= variation of an episode (parent episode's commentator,
+ *                    variation's own PGN + lessonContext + title)
+ *   3. ?shortId=     authored short clip of an episode (slice main PGN)
+ *   4. (default)     full episode
  */
 function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): ResolvedPgnSource {
   if (config.rawPgn) {
@@ -465,6 +478,33 @@ function resolvePgnSource(config: ReturnType<typeof getBroadcastConfig>): Resolv
       lessonContext: undefined,
       commentatorModel: null,
       shortRange: null,
+    };
+  }
+  // Variation capture: replace the long-form PGN + lesson context + title
+  // with the variation's, but keep the parent episode's commentator config.
+  if (config.variationId) {
+    const variation = episode.exports?.variations?.find((v) => v.id === config.variationId);
+    if (!variation) {
+      return {
+        pgnText: episode.pgn,
+        error: `Unknown variationId "${config.variationId}" for episode "${episode.id}". Available: ${
+          episode.exports?.variations?.map((v) => v.id).join(', ') ?? '(none)'
+        }`,
+        historicalContext: episode.historicalContext,
+        lessonContext: episode.commentator.lessonContext,
+        commentatorModel: episode.commentator.model,
+        shortRange: null,
+      };
+    }
+    return {
+      pgnText: variation.pgn,
+      error: null,
+      historicalContext: undefined,
+      lessonContext: variation.lessonContext,
+      commentatorModel: episode.commentator.model,
+      shortRange: null,
+      titleOverride: variation.title,
+      subtitleOverride: variation.summary,
     };
   }
   let shortRange: ResolvedPgnSource['shortRange'] = null;

--- a/src/components/TournamentProgress.tsx
+++ b/src/components/TournamentProgress.tsx
@@ -12,7 +12,8 @@ import { downloadSingleGameJSON } from '../utils/export';
 import { CommentaryQueue, type CommentaryEntry } from '../commentary/commentaryQueue';
 import { createLLMClient } from '../llm/client';
 import { getHistoricalCommentatorPrompt, getLessonCommentatorPrompt, buildBroadcastIntroPrompt, buildPuzzleBreakIntroPrompt, buildPuzzleSetupPromptWithOracle, buildPuzzleCommentaryTurnPromptWithOracle, buildPuzzleOutroPromptWithOracle } from '../llm/prompts';
-import { isBroadcastMode } from '../app/broadcastConfig';
+import { isBroadcastMode, getBroadcastConfig } from '../app/broadcastConfig';
+import { getEpisode } from '../episodes';
 import { runResilientTextGeneration } from '../llm/resilient-text';
 import { fetchLichessPuzzle, getPuzzleFamilyId, prefillPuzzlePool, type LichessPuzzle, type PuzzleTurn } from '../commentary/puzzleBreak';
 import { parseAnnotations, EMPTY_ANNOTATIONS, parsePuzzleMoves, hasAnnotations, mergeAnnotations, type BoardAnnotations } from '../utils/board-annotations';
@@ -471,8 +472,17 @@ export function TournamentProgress() {
         // prompts below and ensures every export has consistent
         // brand framing.
         if (isBroadcastMode()) {
-          const broadcastTitle =
-            replayMode && activeGameState.white.displayName && activeGameState.black.displayName
+          const broadcastCfg = getBroadcastConfig();
+          const broadcastEpisode = broadcastCfg.episodeId ? getEpisode(broadcastCfg.episodeId) : undefined;
+          const activeVariation = broadcastCfg.variationId
+            ? broadcastEpisode?.exports?.variations?.find((v) => v.id === broadcastCfg.variationId)
+            : undefined;
+          // For variation captures the matchup-style title is generic
+          // ("Teacher (W) vs Teacher (B)"). Use the variation title
+          // instead so the intro names the actual content.
+          const broadcastTitle = activeVariation
+            ? activeVariation.title
+            : replayMode && activeGameState.white.displayName && activeGameState.black.displayName
               ? `${activeGameState.white.displayName} vs ${activeGameState.black.displayName}`
               : 'this match';
           const kind: 'historical' | 'lesson' | 'match' = useTournamentStore.getState().replayLessonContext

--- a/src/store/tournamentStore.ts
+++ b/src/store/tournamentStore.ts
@@ -832,18 +832,35 @@ export const useTournamentStore = create<TournamentStore>()(
                 : histCtx
                   ? 'historical'
                   : 'match';
-              const broadcastTitle = replayState
-                ? `${replayState.white.displayName} vs ${replayState.black.displayName}`
-                : 'this match';
-
               // Look up the episode by id (broadcast URL param) so we
               // can pass variation titles to the futures prompt for
               // lesson tracks. No-op for inline-PGN / unregistered ids.
-              const broadcastEpisodeId = getBroadcastConfig().episodeId;
-              const episode = broadcastEpisodeId ? getEpisode(broadcastEpisodeId) : undefined;
-              const variationTitles = kind === 'lesson'
+              //
+              // When capturing a variation (URL ?variationId=<id>),
+              // the futures block is for the variation itself — don't
+              // tease the parent's variation list (it would name-check
+              // the very variation we're recording). Fall back to the
+              // generic "alternative lines you could explore" framing
+              // by leaving variationTitles undefined.
+              const broadcastCfg = getBroadcastConfig();
+              const episode = broadcastCfg.episodeId ? getEpisode(broadcastCfg.episodeId) : undefined;
+              const activeVariation = broadcastCfg.variationId
+                ? episode?.exports?.variations?.find((v) => v.id === broadcastCfg.variationId)
+                : undefined;
+              const isVariationCapture = Boolean(activeVariation);
+              const variationTitles = kind === 'lesson' && !isVariationCapture
                 ? (episode?.exports?.variations ?? []).map((v) => v.title)
                 : undefined;
+
+              // For variation captures the PGN player names are generic
+              // ("Teacher (W)" / "Teacher (B)") — use the variation title
+              // for the outro closer instead. For everything else the
+              // matchup title (white vs black) is the natural framing.
+              const broadcastTitle = activeVariation
+                ? activeVariation.title
+                : replayState
+                  ? `${replayState.white.displayName} vs ${replayState.black.displayName}`
+                  : 'this match';
 
               console.log('[Replay] Generating final-position + futures...');
               await _commentaryQueue.generateIntro(


### PR DESCRIPTION
## Summary

Captures each \`VariationShort\` as its own portrait 1080×1920 MP4 alongside the long-form lesson — the pipeline half of the Track A content cluster ([PR #54](https://github.com/Mnehmos/LLM-Chess/pull/54)).

## CLI

\`\`\`bash
# one variation
npm run export:game -- --episode italian_game_lesson --variation italian_evans_gambit

# subset
npm run export:game -- --episode italian_game_lesson --variation italian_evans_gambit,italian_moller_attack

# all variations for an episode
npm run export:game -- --episode italian_game_lesson --all-variations
\`\`\`

Output lands in [\`exports/<episode>/variations/<variationId>.mp4\`](exports/) (plus the \`_tight.mp4\` dead-air-compressed sibling).

## Plumbing

| Layer | Change |
|---|---|
| [\`broadcastConfig.ts\`](src/app/broadcastConfig.ts) | New \`?variationId=<id>\` URL param |
| [\`BroadcastView.tsx\`](src/components/BroadcastView.tsx) | \`resolvePgnSource\` resolves variation's own PGN / lessonContext / title; parent episode still supplies commentator model |
| [\`BroadcastLayout.tsx\`](src/components/BroadcastLayout.tsx) | \`titleOverride\` / \`subtitleOverride\` props for variation title + summary |
| [\`tournamentStore.ts\`](src/store/tournamentStore.ts) | Variation captures use the variation title for intro + outro framing (not the generic \"Teacher (W) vs Teacher (B)\" PGN headers); futures block stops teasing sibling variations |
| [\`TournamentProgress.tsx\`](src/components/TournamentProgress.tsx) | Same title fix on the standardized brand intro |
| [\`export-chess-mp4.ts\`](scripts/export-chess-mp4.ts) | \`--variation\` / \`--all-variations\` flags, \`selectVariations()\`, variation \`CaptureJob\` with portrait viewport |
| [\`browserCapture.ts\`](scripts/lib/export/browserCapture.ts) | \`CaptureOptions.variationId\` forwarded as \`?variationId=\` |

## Smoke test (\`italian_evans_gambit\`)

| Check | Result |
|---|---|
| Variation PGN ran | ✅ \`\"I got exactly the Evans Gambit setup: b4 pulled the bishop a…\"\` |
| Final-position + futures fired | ✅ \`cq-26: \"So in this final position, I've paid the b-pawn to get the E…\"\` |
| Outro is the last clip | ✅ |
| Resolution | **1080 × 1920** (9:16 portrait) |
| Audio | AAC stereo, 48 kHz, muxed in |
| Tight MP4 length | 9:15 (was 14:36 before dead-air) |
| Output path | \`exports/italian_game_lesson/variations/italian_evans_gambit.mp4\` |

## Test plan

- [x] Typecheck clean
- [x] Single-variation capture produces a portrait MP4 at the expected path
- [ ] \`--all-variations\` produces 4 portrait MP4s for the Italian Game lesson
- [ ] Verify the title fix (variation title in outro, not \"Teacher (W) vs Teacher (B)\")
- [ ] Manual audit of one variation MP4 for upload-readiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for capturing chess line variations as dedicated video files alongside authored shorts
  * Introduced CLI flags to control variation selection during export (`--variation`, `--variations`, `--all-variations`)
  * Enabled variation-specific title and subtitle customization
  * Each captured variation now generates a separate video output file in a dedicated variations directory

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->