### PR TITLE
feat(content): openings batch 1 — Ruy Lopez, Sicilian, French, QGD

### DIFF
--- a/src/episodes/french_winawer_lesson/commentator.ts
+++ b/src/episodes/french_winawer_lesson/commentator.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_COMMENTATOR, type EpisodeCommentatorConfig } from '../types';
+
+export const FRENCH_WINAWER_LESSON_COMMENTATOR: EpisodeCommentatorConfig = {
+  ...DEFAULT_COMMENTATOR,
+  lessonContext: [
+    'Lesson topic: the French Defense, Winawer Variation main line.',
+    'You are an AI teacher demonstrating the opening to a chess student who knows the rules and basic principles but is new to "imbalance" openings.',
+    'Each move on the board is YOUR move — you are playing both sides. Speak in first person: "I play e6 to support d5 and keep the structure asymmetric", "Now I switch to White and play e5 — closing the center and chasing the knight that hasn\'t arrived yet".',
+    'For each move, explain in 1-2 sentences: the IDEA, and one teaching point.',
+    'Cover these themes naturally: the French Defense bargain (Black accepts a passive light-squared bishop in exchange for a rock-solid pawn chain), the Winawer pin (Bb4 attacks Nc3, forcing White to commit), the structural imbalance after Bxc3+ bxc3 (White gets doubled c-pawns AND the bishop pair, Black gets a queenside outpost on a5/c4), why Black\'s queen comes to a5 (pressure on the c3 pawn and dark squares), the c5-c4 push that locks the queenside, the typical race (White kingside attack vs Black queenside expansion).',
+    'Tone: friendly and concrete. Acknowledge the structural complexity — the Winawer is intentionally a strange-looking opening that rewards understanding over memorization. Do NOT reference an audience, a video, "the lesson", or "the result".',
+  ].join(' '),
+};

--- a/src/episodes/french_winawer_lesson/exports.ts
+++ b/src/episodes/french_winawer_lesson/exports.ts
@@ -1,0 +1,12 @@
+import type { EpisodeExportConfig } from '../types';
+import { FRENCH_WINAWER_VARIATIONS } from './variations';
+
+export const FRENCH_WINAWER_LESSON_EXPORT: EpisodeExportConfig = {
+  command: 'npm run export:game -- --episode french_winawer_lesson',
+  outputRoot: 'exports',
+  descriptionCandidates: [
+    "An AI walks through the French Defense (Winawer Variation main line), playing both sides and explaining the structural bargain — Black's queenside outpost vs White's bishop pair and kingside attack — in real time. Part of Oracle Trust Calibration.",
+  ],
+  shorts: [],
+  variations: FRENCH_WINAWER_VARIATIONS,
+};

--- a/src/episodes/french_winawer_lesson/index.ts
+++ b/src/episodes/french_winawer_lesson/index.ts
@@ -1,0 +1,24 @@
+import type { Episode } from '../types';
+import { FRENCH_WINAWER_LESSON_PGN } from './pgn';
+import { FRENCH_WINAWER_LESSON_COMMENTATOR } from './commentator';
+import { FRENCH_WINAWER_VARIATIONS } from './variations';
+import { FRENCH_WINAWER_LESSON_EXPORT } from './exports';
+
+export const FRENCH_WINAWER_LESSON_EPISODE: Episode = {
+  id: 'french_winawer_lesson',
+  track: 'lesson',
+  title: 'French Defense Explained by an AI (Winawer Variation, Move by Move)',
+  summary:
+    "An AI walks through the French Defense (Winawer Variation), playing both sides through the Bb4 pin, the bxc3 doubled-pawn structure, and the race between White's bishop pair and Black's queenside expansion.",
+  source: 'agent_generated',
+  pgn: FRENCH_WINAWER_LESSON_PGN,
+  commentator: FRENCH_WINAWER_LESSON_COMMENTATOR,
+  exports: FRENCH_WINAWER_LESSON_EXPORT,
+};
+
+export {
+  FRENCH_WINAWER_LESSON_PGN,
+  FRENCH_WINAWER_LESSON_COMMENTATOR,
+  FRENCH_WINAWER_VARIATIONS,
+  FRENCH_WINAWER_LESSON_EXPORT,
+};

--- a/src/episodes/french_winawer_lesson/pgn.ts
+++ b/src/episodes/french_winawer_lesson/pgn.ts
@@ -1,0 +1,24 @@
+/**
+ * French Defense — Winawer Variation main line.
+ *
+ * 11-move teaching line covering the most theoretical French. The Winawer
+ * has been a top-tier weapon for Botvinnik, Korchnoi, Bareev, and Aronian.
+ *
+ *   - The French pawn structure (e6/d5 vs e4/d4)
+ *   - The Winawer pin (Bb4) and forced exchange on c3
+ *   - White's doubled c-pawns + bishop pair vs Black's strong squares
+ *     and queenside play
+ *   - Race between Black's c5 push and White's kingside attack
+ */
+export const FRENCH_WINAWER_LESSON_PGN = `[Event "AI Lesson — French Winawer"]
+[Site "—"]
+[Date "2026.05.21"]
+[Round "—"]
+[White "AI Teacher"]
+[Black "AI Teacher (Black side)"]
+[Result "*"]
+[ECO "C18"]
+[Opening "French Defense, Winawer Variation"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. e5 c5 5. a3 Bxc3+ 6. bxc3 Ne7 7. Nf3 Nbc6 8. Bd3 Qa5 9. Qd2 c4 10. Be2 Bd7 11. O-O O-O *
+`;

--- a/src/episodes/french_winawer_lesson/variations.ts
+++ b/src/episodes/french_winawer_lesson/variations.ts
@@ -1,0 +1,84 @@
+import type { VariationShort } from '../types';
+
+export const FRENCH_WINAWER_VARIATIONS: VariationShort[] = [
+  {
+    id: 'french_classical',
+    title: 'French Defense: Classical Variation',
+    pgn: `[Event "French — Classical Variation"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. Bg5 Be7 5. e5 Nfd7 6. Bxe7 Qxe7 7. f4 a6 8. Nf3 c5 9. dxc5 Qxc5 10. Qd2 Nc6 11. O-O-O b5 *
+`,
+    lessonContext:
+      "French Classical (3...Nf6). Instead of the Winawer pin, Black develops the knight to f6 and accepts a position with less structural drama but more typical piece play. The line shown is the Steinitz Variation with 4.Bg5 — the knight is pinned and forced to retreat after 5.e5. Plans: White attacks on the kingside, Black breaks with ...c5 and plays for queenside expansion. Teaching point: the Classical is the French line for players who want the French structure without the Winawer's strange-looking doubled c-pawns.",
+    summary:
+      "The French without the Winawer pin. Solid, structural, easier to learn than the main Winawer line.",
+    hook: "The French Defense, but without the weird doubled pawns.",
+    durationTargetSec: 75,
+  },
+  {
+    id: 'french_tarrasch',
+    title: 'French Defense: Tarrasch Variation',
+    pgn: `[Event "French — Tarrasch Variation"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e6 2. d4 d5 3. Nd2 Nf6 4. e5 Nfd7 5. Bd3 c5 6. c3 Nc6 7. Ne2 cxd4 8. cxd4 f6 9. exf6 Nxf6 10. Nf3 Bd6 11. O-O O-O *
+`,
+    lessonContext:
+      "French Tarrasch (3.Nd2). White sidesteps the Winawer pin by developing the knight to d2 instead of c3. The line shown is the closed Tarrasch with 3...Nf6 and the typical 4.e5 advance. Plans: White builds on the kingside with Nf3, Bd3, O-O; Black breaks with ...c5 and ...f6 to challenge the e5 pawn. Teaching point: Karpov made the Tarrasch his main weapon against the French — it's the line for White players who want a positional, low-theory anti-French.",
+    summary:
+      "White's clever workaround. 3.Nd2 sidesteps the Winawer pin and steers toward calm positional play.",
+    hook: "How White avoids the entire Winawer mess.",
+    durationTargetSec: 75,
+  },
+  {
+    id: 'french_advance',
+    title: 'French Defense: Advance Variation',
+    pgn: `[Event "French — Advance Variation"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e6 2. d4 d5 3. e5 c5 4. c3 Nc6 5. Nf3 Qb6 6. a3 Nh6 7. b4 cxd4 8. cxd4 Nf5 9. Bb2 Be7 10. Bd3 O-O 11. O-O f6 *
+`,
+    lessonContext:
+      "French Advance (3.e5). White locks the center immediately and gains space on move 3. The line shown is the modern main with 5...Qb6 hitting d4 and b2. Plans: White consolidates the chain with c3, a3, b4 and looks to attack with Bd3 + O-O; Black breaks with ...Nh6-f5 (rerouting the knight via h6 because f6 is unavailable), ...f6 to challenge the pawn chain, or queenside pressure with ...Qb6 and ...c4. Teaching point: the Advance is structurally the purest French — the locked pawn chain is the position the French was named for.",
+    summary:
+      'White locks the center on move 3. The purest French pawn chain — same opening as the Winawer, different character.',
+    hook: 'The French position the opening was named for.',
+    durationTargetSec: 75,
+  },
+  {
+    id: 'french_exchange',
+    title: 'French Defense: Exchange Variation',
+    pgn: `[Event "French — Exchange Variation"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e6 2. d4 d5 3. exd5 exd5 4. Bd3 Nc6 5. c3 Nf6 6. Nf3 Bd6 7. O-O O-O 8. Bg5 h6 9. Bh4 Bg4 10. Nbd2 Re8 11. Re1 Qd7 *
+`,
+    lessonContext:
+      "French Exchange (3.exd5 exd5). The 'drawing' line — White trades central tension for a symmetrical pawn structure. Both sides have IQP-free positions with mirrored pieces. Plans: each side develops naturally, looks for kingside attacks, and tries to outplay the other in a position with almost zero structural imbalance. Teaching point: the Exchange is the French line White picks when they want a quiet day — but black actually scores well here at the club level because Black knows the structure better than White does.",
+    summary:
+      "The 'boring' anti-French. White trades into a symmetric structure — but Black often outplays White anyway.",
+    hook: 'The line White plays to avoid the French — that Black wins anyway.',
+    durationTargetSec: 65,
+  },
+];

--- a/src/episodes/italian_game_lesson/index.ts
+++ b/src/episodes/italian_game_lesson/index.ts
@@ -18,7 +18,7 @@ import { ITALIAN_GAME_EXPORT } from './exports';
 export const ITALIAN_GAME_LESSON_EPISODE: Episode = {
   id: 'italian_game_lesson',
   track: 'lesson',
-  title: 'AI Teaches the Italian Game',
+  title: 'Italian Game Explained by an AI (Giuoco Piano, Move by Move)',
   summary:
     'An AI walks through the Italian Game (Giuoco Piano main line), playing both sides of a 12-move demonstration and explaining each idea in real time.',
   source: 'agent_generated',

--- a/src/episodes/qgd_orthodox_lesson/commentator.ts
+++ b/src/episodes/qgd_orthodox_lesson/commentator.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_COMMENTATOR, type EpisodeCommentatorConfig } from '../types';
+
+export const QGD_ORTHODOX_LESSON_COMMENTATOR: EpisodeCommentatorConfig = {
+  ...DEFAULT_COMMENTATOR,
+  lessonContext: [
+    'Lesson topic: the Queen\'s Gambit Declined, Orthodox Defense main line.',
+    'You are an AI teacher demonstrating the most classical Queen\'s pawn opening to a chess student who has seen 1.e4 lines but is new to 1.d4 structures.',
+    'Each move on the board is YOUR move — you are playing both sides. Speak in first person: "I play d4 to claim the center on a different square than 1.e4 does", "Now I switch to Black and play d5 to mirror — and decline the gambit pawn".',
+    'For each move, explain in 1-2 sentences: the IDEA, and one teaching point.',
+    'Cover these themes naturally: why 2.c4 is "the Queen\'s Gambit" but the pawn isn\'t really hangable (Black can never hold it), the QGD trade Black accepts (a slightly cramped position for rock-solid structure), the Capablanca Freeing Maneuver (...Nd5 to trade off pieces and ease the cramp), why ...c6 supports d5 BEFORE moving the b-knight, the minority attack plan (b4-b5 on the queenside trying to create a weak c-pawn), the Bg5 pin and when to break it with ...h6, classical development principles in a structure where the bishops fight for the c-file diagonal.',
+    'Tone: friendly and concrete. Reference Capablanca\'s famous freeing maneuver by name — historical credit matters in 1.d4 openings. Do NOT reference an audience, a video, "the lesson", or "the result".',
+  ].join(' '),
+};

--- a/src/episodes/qgd_orthodox_lesson/exports.ts
+++ b/src/episodes/qgd_orthodox_lesson/exports.ts
@@ -1,0 +1,12 @@
+import type { EpisodeExportConfig } from '../types';
+import { QGD_ORTHODOX_VARIATIONS } from './variations';
+
+export const QGD_ORTHODOX_LESSON_EXPORT: EpisodeExportConfig = {
+  command: 'npm run export:game -- --episode qgd_orthodox_lesson',
+  outputRoot: 'exports',
+  descriptionCandidates: [
+    "An AI walks through the Queen's Gambit Declined (Orthodox Defense), playing both sides through the Capablanca freeing maneuver and explaining the structural tradeoffs of 1.d4 chess. Part of Oracle Trust Calibration.",
+  ],
+  shorts: [],
+  variations: QGD_ORTHODOX_VARIATIONS,
+};

--- a/src/episodes/qgd_orthodox_lesson/index.ts
+++ b/src/episodes/qgd_orthodox_lesson/index.ts
@@ -1,0 +1,24 @@
+import type { Episode } from '../types';
+import { QGD_ORTHODOX_LESSON_PGN } from './pgn';
+import { QGD_ORTHODOX_LESSON_COMMENTATOR } from './commentator';
+import { QGD_ORTHODOX_VARIATIONS } from './variations';
+import { QGD_ORTHODOX_LESSON_EXPORT } from './exports';
+
+export const QGD_ORTHODOX_LESSON_EPISODE: Episode = {
+  id: 'qgd_orthodox_lesson',
+  track: 'lesson',
+  title: "Queen's Gambit Declined Explained by an AI (Orthodox Defense, Move by Move)",
+  summary:
+    "An AI walks through the Queen's Gambit Declined (Orthodox Defense), playing both sides through Capablanca's freeing maneuver and explaining the QGD's structural tradeoffs — solid pawn chain, slightly cramped piece play, minority-attack endgames.",
+  source: 'agent_generated',
+  pgn: QGD_ORTHODOX_LESSON_PGN,
+  commentator: QGD_ORTHODOX_LESSON_COMMENTATOR,
+  exports: QGD_ORTHODOX_LESSON_EXPORT,
+};
+
+export {
+  QGD_ORTHODOX_LESSON_PGN,
+  QGD_ORTHODOX_LESSON_COMMENTATOR,
+  QGD_ORTHODOX_VARIATIONS,
+  QGD_ORTHODOX_LESSON_EXPORT,
+};

--- a/src/episodes/qgd_orthodox_lesson/pgn.ts
+++ b/src/episodes/qgd_orthodox_lesson/pgn.ts
@@ -1,0 +1,23 @@
+/**
+ * Queen's Gambit Declined — Orthodox Defense main line.
+ *
+ * 12-move teaching line covering the most classical Queen's pawn opening.
+ * Used in five world championship matches and still played at top level.
+ *
+ *   - White's d4-c4 setup challenging Black's center
+ *   - Black declines with ...e6 (the Orthodox), keeping the structure solid
+ *   - The Capablanca freeing maneuver (...Nd5 to liquidate)
+ *   - White's minority attack vs Black's e6/d5 pawn chain
+ */
+export const QGD_ORTHODOX_LESSON_PGN = `[Event "AI Lesson — QGD Orthodox"]
+[Site "—"]
+[Date "2026.05.21"]
+[Round "—"]
+[White "AI Teacher"]
+[Black "AI Teacher (Black side)"]
+[Result "*"]
+[ECO "D63"]
+[Opening "Queen's Gambit Declined, Orthodox Defense"]
+
+1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Bg5 Be7 5. e3 O-O 6. Nf3 Nbd7 7. Rc1 c6 8. Bd3 dxc4 9. Bxc4 Nd5 10. Bxe7 Qxe7 11. O-O Nxc3 12. Rxc3 e5 *
+`;

--- a/src/episodes/qgd_orthodox_lesson/variations.ts
+++ b/src/episodes/qgd_orthodox_lesson/variations.ts
@@ -1,0 +1,84 @@
+import type { VariationShort } from '../types';
+
+export const QGD_ORTHODOX_VARIATIONS: VariationShort[] = [
+  {
+    id: 'qgd_slav_defense',
+    title: "Queen's Gambit: Slav Defense",
+    pgn: `[Event "QGD — Slav Defense"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. Nc3 dxc4 5. a4 Bf5 6. e3 e6 7. Bxc4 Bb4 8. O-O Nbd7 9. Qe2 Bg6 10. e4 O-O 11. Bd3 Bxc3 *
+`,
+    lessonContext:
+      "Slav Defense (2...c6). Instead of locking in the light-squared bishop with ...e6, Black supports d5 with the c-pawn. This keeps Black's bishop free to develop to f5 or g4. The line shown is the Main Line Slav with 4...dxc4 5.a4 Bf5 — Black grabs the pawn but White recovers it with a4 stopping ...b5. Plans: Black develops actively (Bf5, Nbd7, e6 only later); White builds with e3/Bxc4 and looks for e4 break. Teaching point: the Slav is the only line where Black can develop the c8-bishop OUTSIDE the pawn chain — which is why it's so popular.",
+    summary:
+      "Support d5 with c6 instead of e6. Solves the French / QGD bad-bishop problem.",
+    hook: "Why support d5 with c6 instead of e6?",
+    durationTargetSec: 80,
+  },
+  {
+    id: 'qgd_semi_slav',
+    title: "Queen's Gambit: Semi-Slav Defense",
+    pgn: `[Event "QGD — Semi-Slav Defense"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. d4 d5 2. c4 c6 3. Nc3 Nf6 4. Nf3 e6 5. Bg5 h6 6. Bh4 dxc4 7. e4 g5 8. Bg3 b5 9. Be2 Bb7 10. h4 g4 11. Ne5 h5 *
+`,
+    lessonContext:
+      "Semi-Slav (2...c6 then ...e6). Black plays BOTH c6 and e6, locking in the bishop AND supporting d5 from two squares. The line shown is the sharp Botvinnik System (or Anti-Meran) where Black grabs the c-pawn AND pushes ...g5 to harass the bishop. Plans: Black creates a strong queenside pawn chain with ...b5-b4 and counterattacks with ...c5; White breaks open the center with e4 and attacks the wandering king. Teaching point: the Semi-Slav is the most theoretical 1.d4 defense — the Botvinnik Variation is the equal of any Najdorf line in complexity.",
+    summary:
+      "The most theoretical 1.d4 defense. Both sides commit, both sides attack — pawn grabs and counter-attacks.",
+    hook: "Both c6 AND e6 — and a Najdorf-level theory dump.",
+    durationTargetSec: 85,
+  },
+  {
+    id: 'qgd_cambridge_springs',
+    title: "Queen's Gambit Declined: Cambridge Springs",
+    pgn: `[Event "QGD — Cambridge Springs"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Bg5 Nbd7 5. e3 c6 6. Nf3 Qa5 7. Nd2 Bb4 8. Qc2 O-O 9. Be2 e5 10. O-O exd4 11. exd4 dxc4 *
+`,
+    lessonContext:
+      "Cambridge Springs Defense (5...c6 6.Nf3 Qa5). An ingenious tactical idea — Black brings the queen out to a5 to hit BOTH the c3 knight AND the g5 bishop simultaneously, exploiting the pinned-piece geometry. The threat is ...Ne4 winning material if White is careless. Plans: White typically responds with Nd2 (unpinning) or cxd5 (releasing the central tension); Black plays for ...Bb4 and ...Ne4 with active piece play. Teaching point: the Cambridge Springs is the line for players who want the QGD structure but with a built-in tactical idea — and it's strong, scoring well at the top level.",
+    summary:
+      "The QGD with a built-in tactic. Black's queen-out-to-a5 hits two pieces and threatens immediate problems.",
+    hook: "The QGD with a tactic baked into move 6.",
+    durationTargetSec: 80,
+  },
+  {
+    id: 'qgd_tartakower',
+    title: "Queen's Gambit Declined: Tartakower Defense",
+    pgn: `[Event "QGD — Tartakower Defense"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Bg5 Be7 5. e3 h6 6. Bh4 O-O 7. Nf3 b6 8. cxd5 Nxd5 9. Bxe7 Qxe7 10. Nxd5 exd5 11. Rc1 Be6 *
+`,
+    lessonContext:
+      "Tartakower Defense (5...h6 6.Bh4 b6). Black breaks the pin with ...h6, gets a tempo by chasing the bishop, then fianchettoes the c8-bishop with ...b6. This solves the QGD's perpetual problem (the locked-in c8-bishop) at the cost of a slightly cramped position. The line shown ends in a typical Carlsbad-like structure after exchanges on d5. Plans: White looks for the minority attack with b4-b5; Black uses the bishop pair and aims for ...c5 or ...e5 breaks. Teaching point: the Tartakower was Karpov's favorite — it's the QGD for players who want active piece play, not the cramped Orthodox.",
+    summary:
+      "Karpov's favorite QGD. Solves the bad-bishop problem with ...b6 and a fianchetto.",
+    hook: "How Karpov solved the QGD's worst piece.",
+    durationTargetSec: 75,
+  },
+];

--- a/src/episodes/registry.ts
+++ b/src/episodes/registry.ts
@@ -1,5 +1,9 @@
 import { OPERA_GAME_EPISODE } from './opera_game_morphy_1858';
 import { ITALIAN_GAME_LESSON_EPISODE } from './italian_game_lesson';
+import { RUY_LOPEZ_LESSON_EPISODE } from './ruy_lopez_lesson';
+import { SICILIAN_NAJDORF_LESSON_EPISODE } from './sicilian_najdorf_lesson';
+import { FRENCH_WINAWER_LESSON_EPISODE } from './french_winawer_lesson';
+import { QGD_ORTHODOX_LESSON_EPISODE } from './qgd_orthodox_lesson';
 import type { Episode, EpisodeSource } from './types';
 
 /**
@@ -11,6 +15,10 @@ import type { Episode, EpisodeSource } from './types';
 export const CHESS_EPISODES: Episode[] = [
   OPERA_GAME_EPISODE,
   ITALIAN_GAME_LESSON_EPISODE,
+  RUY_LOPEZ_LESSON_EPISODE,
+  SICILIAN_NAJDORF_LESSON_EPISODE,
+  FRENCH_WINAWER_LESSON_EPISODE,
+  QGD_ORTHODOX_LESSON_EPISODE,
 ];
 
 /** Default episode id when no `?episode=` is specified. */

--- a/src/episodes/ruy_lopez_lesson/commentator.ts
+++ b/src/episodes/ruy_lopez_lesson/commentator.ts
@@ -1,0 +1,16 @@
+import { DEFAULT_COMMENTATOR, type EpisodeCommentatorConfig } from '../types';
+
+/**
+ * Commentator config for the Ruy Lopez lesson. TEACHER mode.
+ */
+export const RUY_LOPEZ_LESSON_COMMENTATOR: EpisodeCommentatorConfig = {
+  ...DEFAULT_COMMENTATOR,
+  lessonContext: [
+    'Lesson topic: the Ruy Lopez (Spanish Game), Closed Defense main line.',
+    'You are an AI teacher demonstrating the opening to a chess student who knows the rules and basic principles but is new to opening theory.',
+    'Each move on the board is YOUR move — you are playing both sides. Speak in first person: "I play Bb5 to pin the knight that defends e5", "Now I switch to Black and play a6 to ask the bishop a question".',
+    'For each move, explain in 1-2 sentences: the IDEA (what the move accomplishes), and one teaching point (a principle, a common student mistake, or a typical follow-up plan).',
+    'Cover these themes naturally as they come up: the pin on c6 and how Black breaks it with a6/Ba4 (the "Morphy" move), the Spanish bishop\'s long retreat Bb5-Ba4-Bb3-Bc2 (NOT capturing on c6), why Black plays b5 (gain space, hit the bishop, prepare ...d6/...Be7), the c3-d4 break that defines White\'s plan, knight maneuvers (Na5-c6 reroute), Black\'s solid but cramped structure.',
+    'Tone: friendly and concrete. Avoid jargon when a plain word works. Do NOT reference an audience, a video, "the lesson", or "the result" — just teach the moves.',
+  ].join(' '),
+};

--- a/src/episodes/ruy_lopez_lesson/exports.ts
+++ b/src/episodes/ruy_lopez_lesson/exports.ts
@@ -1,0 +1,12 @@
+import type { EpisodeExportConfig } from '../types';
+import { RUY_LOPEZ_VARIATIONS } from './variations';
+
+export const RUY_LOPEZ_LESSON_EXPORT: EpisodeExportConfig = {
+  command: 'npm run export:game -- --episode ruy_lopez_lesson',
+  outputRoot: 'exports',
+  descriptionCandidates: [
+    'An AI walks through the Ruy Lopez (Closed Defense main line), playing both sides and explaining each idea in real time. Part of Oracle Trust Calibration — a research show using chess to benchmark how LLMs behave under unreliable context.',
+  ],
+  shorts: [],
+  variations: RUY_LOPEZ_VARIATIONS,
+};

--- a/src/episodes/ruy_lopez_lesson/index.ts
+++ b/src/episodes/ruy_lopez_lesson/index.ts
@@ -1,0 +1,24 @@
+import type { Episode } from '../types';
+import { RUY_LOPEZ_LESSON_PGN } from './pgn';
+import { RUY_LOPEZ_LESSON_COMMENTATOR } from './commentator';
+import { RUY_LOPEZ_VARIATIONS } from './variations';
+import { RUY_LOPEZ_LESSON_EXPORT } from './exports';
+
+export const RUY_LOPEZ_LESSON_EPISODE: Episode = {
+  id: 'ruy_lopez_lesson',
+  track: 'lesson',
+  title: 'Ruy Lopez Explained by an AI (Closed Defense, Move by Move)',
+  summary:
+    "An AI walks through the Ruy Lopez (Closed Defense main line), playing both sides of a 12-move demonstration and explaining each idea — the pin on c6, the Spanish bishop's long retreat, and the c3-d4 break — in real time.",
+  source: 'agent_generated',
+  pgn: RUY_LOPEZ_LESSON_PGN,
+  commentator: RUY_LOPEZ_LESSON_COMMENTATOR,
+  exports: RUY_LOPEZ_LESSON_EXPORT,
+};
+
+export {
+  RUY_LOPEZ_LESSON_PGN,
+  RUY_LOPEZ_LESSON_COMMENTATOR,
+  RUY_LOPEZ_VARIATIONS,
+  RUY_LOPEZ_LESSON_EXPORT,
+};

--- a/src/episodes/ruy_lopez_lesson/pgn.ts
+++ b/src/episodes/ruy_lopez_lesson/pgn.ts
@@ -1,0 +1,26 @@
+/**
+ * Ruy Lopez (Spanish Game) — Closed Defense main line.
+ *
+ * 12-move teaching line covering the classical Closed Spanish through
+ * the Chigorin Defense setup. Selected to showcase:
+ *   - The pin on c6 and Black's a6/Ba4 response
+ *   - The Spanish bishop's long retreat (Bb5-Ba4-Bb3-Bc2)
+ *   - Central tension without an immediate break
+ *   - Maneuvering chess — knights to the rim then back to the center
+ *     (the Knight tour Nb1-d2-f1-g3 is the same idea as the Italian)
+ *
+ * Ends in a balanced middlegame typical of the Closed Spanish, where
+ * White's space advantage and Black's solid structure are both intact.
+ */
+export const RUY_LOPEZ_LESSON_PGN = `[Event "AI Lesson — Ruy Lopez Closed"]
+[Site "—"]
+[Date "2026.05.21"]
+[Round "—"]
+[White "AI Teacher"]
+[Black "AI Teacher (Black side)"]
+[Result "*"]
+[ECO "C84"]
+[Opening "Ruy Lopez, Closed Defense"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Na5 10. Bc2 c5 11. d4 Qc7 12. Nbd2 Nc6 *
+`;

--- a/src/episodes/ruy_lopez_lesson/variations.ts
+++ b/src/episodes/ruy_lopez_lesson/variations.ts
@@ -1,0 +1,84 @@
+import type { VariationShort } from '../types';
+
+export const RUY_LOPEZ_VARIATIONS: VariationShort[] = [
+  {
+    id: 'ruy_lopez_berlin_defense',
+    title: 'Ruy Lopez: Berlin Defense',
+    pgn: `[Event "Ruy Lopez — Berlin Defense"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 Nf6 4. O-O Nxe4 5. d4 Nd6 6. Bxc6 dxc6 7. dxe5 Nf5 8. Qxd8+ Kxd8 9. Nc3 Ke8 10. h3 h6 11. Rd1 Bd7 *
+`,
+    lessonContext:
+      "Berlin Defense (3...Nf6). Black skips the symmetric a6 and challenges e4 immediately. The line shown is the Berlin Wall endgame after 4.O-O Nxe4 5.d4 Nd6 6.Bxc6 dxc6 7.dxe5 Nf5 8.Qxd8+ Kxd8 — Kramnik famously used this against Kasparov in 2000 to neutralize the world champion's white. The point: Black trades queens early and accepts a long-term structural concession (doubled c-pawns, king on d8) in exchange for a position with very little dynamic risk. Teaching point: if you can play the Berlin endgame well, you have a complete defense to 1.e4.",
+    summary:
+      "The endgame defense that neutralized Kasparov. Black trades queens early and walks into a structurally weird but very solid Wall position.",
+    hook: "How do you beat 1.e4 without theory?",
+    durationTargetSec: 80,
+  },
+  {
+    id: 'ruy_lopez_exchange_variation',
+    title: 'Ruy Lopez: Exchange Variation',
+    pgn: `[Event "Ruy Lopez — Exchange Variation"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Bxc6 dxc6 5. O-O f6 6. d4 exd4 7. Nxd4 c5 8. Nb3 Qxd1 9. Rxd1 Bd7 10. Nc3 O-O-O *
+`,
+    lessonContext:
+      "Exchange Variation (4.Bxc6). Instead of retreating, White takes the knight and accepts doubling Black's pawns. Black recaptures with dxc6 to keep the d-file open. The line transitions quickly into an endgame where White's structural edge (4 vs 3 pawn majority on the kingside) is balanced against Black's bishop pair and slightly better piece activity. Teaching point: trading pieces does NOT mean ducking the fight — White is playing for a long, slow technical endgame win, the kind that won Fischer many games with 4.Bxc6.",
+    summary:
+      'Trade now, win later. White takes the knight, doubles Black\'s pawns, and aims for a long endgame grind.',
+    hook: 'Why would you trade your prized Spanish bishop on move 4?',
+    durationTargetSec: 75,
+  },
+  {
+    id: 'ruy_lopez_open_spanish',
+    title: 'Ruy Lopez: Open Spanish',
+    pgn: `[Event "Ruy Lopez — Open Spanish"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Nxe4 6. d4 b5 7. Bb3 d5 8. dxe5 Be6 9. c3 Bc5 10. Nbd2 O-O 11. Bc2 f5 *
+`,
+    lessonContext:
+      "Open Spanish (5...Nxe4). Black grabs the e-pawn and accepts a sharper, more dynamic position than the Closed Spanish allows. The key tabiya appears after 6.d4 b5 7.Bb3 d5 — Black builds a big pawn center while White prepares to fight for it. The Bb3-c2 maneuver targets Black's kingside, while Black's c2-c5 break and f7-f5 push generate counterplay. Teaching point: in the Open Spanish both sides commit early — this is NOT a positional opening, it's a race to mobilize the bigger pawn center.",
+    summary:
+      'Grab the pawn, build the center, and brace for a fight. The Open Spanish is the sharper alternative to the Closed Defense.',
+    hook: 'What if Black just takes the e-pawn?',
+    durationTargetSec: 80,
+  },
+  {
+    id: 'ruy_lopez_marshall_attack',
+    title: 'Ruy Lopez: Marshall Attack',
+    pgn: `[Event "Ruy Lopez — Marshall Attack"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 O-O 8. c3 d5 9. exd5 Nxd5 10. Nxe5 Nxe5 11. Rxe5 c6 *
+`,
+    lessonContext:
+      "Marshall Attack (8...d5). Black sacrifices a central pawn for a long-lasting kingside attack. After 8.c3 (preparing d4) Black plays d5! immediately, opening lines before White can solidify. The sacrificed pawn buys Black active piece play, an open d-file, and threats against White's king. Teaching point: the Marshall is the gambit that's worth all the theory — even at the world-championship level, most top players avoid this with the anti-Marshall 8.a4 or 8.h3 rather than testing the main line. It's a complete attacking weapon vs the Closed Spanish.",
+    summary:
+      'Sacrifice a pawn for a long-lasting attack. Most elite Whites duck this with 8.h3 rather than test the main line.',
+    hook: 'A pawn sacrifice so strong, top players refuse to enter it.',
+    durationTargetSec: 85,
+  },
+];

--- a/src/episodes/sicilian_najdorf_lesson/commentator.ts
+++ b/src/episodes/sicilian_najdorf_lesson/commentator.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_COMMENTATOR, type EpisodeCommentatorConfig } from '../types';
+
+export const SICILIAN_NAJDORF_LESSON_COMMENTATOR: EpisodeCommentatorConfig = {
+  ...DEFAULT_COMMENTATOR,
+  lessonContext: [
+    'Lesson topic: the Sicilian Defense, Najdorf Variation, English Attack main line.',
+    'You are an AI teacher demonstrating the opening to a chess student who knows basic openings (Italian, French) but is new to the sharp lines of the Open Sicilian.',
+    'Each move on the board is YOUR move — you are playing both sides. Speak in first person: "I play c5 to fight for the d4 square asymmetrically", "Now I switch to White and play d4 — the Open Sicilian break".',
+    'For each move, explain in 1-2 sentences: the IDEA (what the move accomplishes), and one teaching point (a principle, a typical mistake, or a follow-up plan).',
+    'Cover these themes naturally: the asymmetric pawn structure (Black gives up the d-file in exchange for the c-file and queenside space), why ...a6 is THE Najdorf move (restrains Bb5, prepares ...b5 and ...e5), opposite-side castling races (White castles long, Black short, both pawnstorm), the English Attack plan (f3-Be3-Qd2-O-O-O-g4-h4), why ...Nbd7 over ...Nc6 (saves the knight for ...Nb6 or ...Nc5 maneuvers).',
+    'Tone: friendly and concrete, but acknowledge complexity — the Najdorf is theory-heavy by design. Do NOT reference an audience, a video, "the lesson", or "the result".',
+  ].join(' '),
+};

--- a/src/episodes/sicilian_najdorf_lesson/exports.ts
+++ b/src/episodes/sicilian_najdorf_lesson/exports.ts
@@ -1,0 +1,12 @@
+import type { EpisodeExportConfig } from '../types';
+import { SICILIAN_NAJDORF_VARIATIONS } from './variations';
+
+export const SICILIAN_NAJDORF_LESSON_EXPORT: EpisodeExportConfig = {
+  command: 'npm run export:game -- --episode sicilian_najdorf_lesson',
+  outputRoot: 'exports',
+  descriptionCandidates: [
+    'An AI walks through the Sicilian Defense (Najdorf Variation, English Attack), playing both sides and explaining each idea in real time. Part of Oracle Trust Calibration — a research show using chess to benchmark how LLMs behave under unreliable context.',
+  ],
+  shorts: [],
+  variations: SICILIAN_NAJDORF_VARIATIONS,
+};

--- a/src/episodes/sicilian_najdorf_lesson/index.ts
+++ b/src/episodes/sicilian_najdorf_lesson/index.ts
@@ -1,0 +1,24 @@
+import type { Episode } from '../types';
+import { SICILIAN_NAJDORF_LESSON_PGN } from './pgn';
+import { SICILIAN_NAJDORF_LESSON_COMMENTATOR } from './commentator';
+import { SICILIAN_NAJDORF_VARIATIONS } from './variations';
+import { SICILIAN_NAJDORF_LESSON_EXPORT } from './exports';
+
+export const SICILIAN_NAJDORF_LESSON_EPISODE: Episode = {
+  id: 'sicilian_najdorf_lesson',
+  track: 'lesson',
+  title: 'Sicilian Defense Explained by an AI (Najdorf Variation, Move by Move)',
+  summary:
+    'An AI walks through the Sicilian Najdorf (English Attack main line), playing both sides through opposite-side castling and explaining each idea — the Open Sicilian break, the ...a6 move, the f3-Be3-Qd2-O-O-O setup — in real time.',
+  source: 'agent_generated',
+  pgn: SICILIAN_NAJDORF_LESSON_PGN,
+  commentator: SICILIAN_NAJDORF_LESSON_COMMENTATOR,
+  exports: SICILIAN_NAJDORF_LESSON_EXPORT,
+};
+
+export {
+  SICILIAN_NAJDORF_LESSON_PGN,
+  SICILIAN_NAJDORF_LESSON_COMMENTATOR,
+  SICILIAN_NAJDORF_VARIATIONS,
+  SICILIAN_NAJDORF_LESSON_EXPORT,
+};

--- a/src/episodes/sicilian_najdorf_lesson/pgn.ts
+++ b/src/episodes/sicilian_najdorf_lesson/pgn.ts
@@ -1,0 +1,24 @@
+/**
+ * Sicilian Defense — Najdorf Variation, English Attack main line.
+ *
+ * 11-move teaching line covering the most popular Sicilian by reputation.
+ * The Najdorf is the variation Fischer, Kasparov, Topalov and Carlsen
+ * have all leaned on as their main weapon against 1.e4.
+ *
+ *   - The Open Sicilian: White's d4 break, Black takes
+ *   - Black's a6 (the Najdorf move) restraining b5 and Bb5 ideas
+ *   - The English Attack with f3 + Be3 + Qd2 + O-O-O
+ *   - Black's typical e6 / Be7 / O-O setup before counterattacking
+ */
+export const SICILIAN_NAJDORF_LESSON_PGN = `[Event "AI Lesson — Sicilian Najdorf"]
+[Site "—"]
+[Date "2026.05.21"]
+[Round "—"]
+[White "AI Teacher"]
+[Black "AI Teacher (Black side)"]
+[Result "*"]
+[ECO "B90"]
+[Opening "Sicilian Defense, Najdorf Variation"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 6. Be3 e6 7. f3 Be7 8. Qd2 O-O 9. O-O-O Nbd7 10. g4 b5 11. g5 Nh5 *
+`;

--- a/src/episodes/sicilian_najdorf_lesson/variations.ts
+++ b/src/episodes/sicilian_najdorf_lesson/variations.ts
@@ -1,0 +1,84 @@
+import type { VariationShort } from '../types';
+
+export const SICILIAN_NAJDORF_VARIATIONS: VariationShort[] = [
+  {
+    id: 'sicilian_dragon',
+    title: 'Sicilian Defense: Dragon Variation',
+    pgn: `[Event "Sicilian — Dragon Variation"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 O-O 8. Qd2 Nc6 9. Bc4 Bd7 10. O-O-O Rc8 11. Bb3 Ne5 *
+`,
+    lessonContext:
+      "Sicilian Dragon (5...g6). Black fianchettoes the king's bishop into a fearsome diagonal aimed at White's queenside. The line shown is the Yugoslav Attack — White's most ambitious try, with the king castling queenside and h-pawn pawnstorming the Dragon castle. Black counterpunches on the c-file and a-file. Teaching point: the Dragon is the most theory-dependent Sicilian line — a single tempo lost in the pawnstorm race can decide the game. Both sides race for mate.",
+    summary:
+      'The most aggressive Sicilian. Both sides castle on opposite wings, both pawnstorm, and the first attacker through wins.',
+    hook: 'A theoretical pawnstorm race for opposite-side mate.',
+    durationTargetSec: 80,
+  },
+  {
+    id: 'sicilian_scheveningen',
+    title: 'Sicilian Defense: Scheveningen',
+    pgn: `[Event "Sicilian — Scheveningen"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e6 6. Be2 Be7 7. O-O O-O 8. f4 Nc6 9. Be3 a6 10. a4 Qc7 11. Kh1 Re8 *
+`,
+    lessonContext:
+      "Sicilian Scheveningen (5...e6). Black builds the 'small center' (e6 + d6) and develops solidly without grabbing space. The line shown is the Classical Scheveningen with White's Maroczy/Kasparov-style setup (Be2, O-O, f4). Plans: White looks for f4-f5 break and kingside attack; Black plays for ...b5-b4 queenside expansion and ...d5 central break. Teaching point: the Scheveningen is the Sicilian for a player who wants Black's positional ideas without the Najdorf's memorization burden.",
+    summary:
+      'The "small center" Sicilian. Solid, principled, less theory than the Najdorf or Dragon.',
+    hook: 'The Sicilian with no early commitments.',
+    durationTargetSec: 75,
+  },
+  {
+    id: 'sicilian_sveshnikov',
+    title: 'Sicilian Defense: Sveshnikov Variation',
+    pgn: `[Event "Sicilian — Sveshnikov"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 e5 6. Ndb5 d6 7. Bg5 a6 8. Na3 b5 9. Nd5 Be7 10. Bxf6 Bxf6 11. c3 O-O *
+`,
+    lessonContext:
+      "Sicilian Sveshnikov (4...Nf6 5.Nc3 e5). Black plays the bold ...e5 on move 5, accepting a hole on d5 in exchange for active piece play and a strong dark-squared bishop. The line shown is the modern main line with Nd5, exchange on f6, and Black's ...O-O. Teaching point: the Sveshnikov was Magnus Carlsen's main Sicilian during his world-championship matches against Caruana (2018) — modern engines confirm Black is fully fine despite the structural concession.",
+    summary:
+      "Carlsen's Sicilian. Black creates a permanent hole on d5 and trusts in piece play to compensate.",
+    hook: 'A hole on d5, accepted on purpose.',
+    durationTargetSec: 80,
+  },
+  {
+    id: 'sicilian_closed',
+    title: 'Sicilian Defense: Closed Sicilian',
+    pgn: `[Event "Sicilian — Closed Sicilian"]
+[Site "Lesson"]
+[Date "????.??.??"]
+[Round "-"]
+[White "Teacher (W)"]
+[Black "Teacher (B)"]
+[Result "*"]
+
+1. e4 c5 2. Nc3 Nc6 3. g3 g6 4. Bg2 Bg7 5. d3 d6 6. Be3 e6 7. Qd2 Nge7 8. Nf3 Nd4 9. O-O O-O 10. Nh4 Rb8 11. f4 b6 *
+`,
+    lessonContext:
+      "Closed Sicilian (2.Nc3). White declines the Open Sicilian's theoretical battle and plays a King's Indian Attack-style positional game instead. The line shown is the classical setup with Bg2 fianchetto, f4 push, and a slow kingside attack. Plans: White attacks on the kingside with f4-f5; Black counters with a queenside pawnstorm (b5, b4). Teaching point: the Closed Sicilian is the choice for White players who want to avoid Najdorf theory entirely — Spassky played it his whole career and won World Championship games with it.",
+    summary:
+      "Avoid the Najdorf theory entirely. White plays a King's Indian Attack-style positional Sicilian.",
+    hook: 'The Sicilian without the theory.',
+    durationTargetSec: 75,
+  },
+];


### PR DESCRIPTION
## Summary

Adds 4 new Track A lesson episodes and renames the Italian Game title to match the new series convention.

## Series title convention

\`X Explained by an AI (Y, Move by Move)\` — where **X** is the opening's proper name and **Y** is the specific named line being demonstrated.

- Italian Game Explained by an AI (Giuoco Piano, Move by Move) — rename
- Ruy Lopez Explained by an AI (Closed Defense, Move by Move) — new
- Sicilian Defense Explained by an AI (Najdorf Variation, Move by Move) — new
- French Defense Explained by an AI (Winawer Variation, Move by Move) — new
- Queen's Gambit Declined Explained by an AI (Orthodox Defense, Move by Move) — new

## Variation clusters

Each new episode ships with 4 line-variation Shorts:

| Episode | Variations |
|---|---|
| Ruy Lopez | Berlin Defense, Exchange Variation, Open Spanish, Marshall Attack |
| Sicilian Najdorf | Dragon, Scheveningen, Sveshnikov, Closed Sicilian |
| French Winawer | Classical, Tarrasch, Advance, Exchange |
| QGD Orthodox | Slav, Semi-Slav, Cambridge Springs, Tartakower |

## Validation

All 25 PGN lines (5 main + 20 variations) parse cleanly through chess.js. Caught one typo before merge (\`Nh1\` → \`Nh4\` in the Closed Sicilian variation).

## Test plan

- [x] Typecheck clean
- [x] All 25 PGNs parse via chess.js
- [ ] Smoke capture of one new episode + one variation to verify they run end-to-end
- [ ] Full slate capture (5 episodes × 5 PGNs × 2 orientations = 50 MP4s — defer to batch capture session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)