### PR TITLE
feat(broadcast): ghost arrows + book-standards schema

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -64,12 +64,25 @@ function AnnotationOverlay({
 
   const hasContent =
     moveArrows.length > 0 ||
-    (annotations && (annotations.arrows.length > 0 || annotations.highlights.length > 0 || annotations.circles.length > 0));
+    (annotations &&
+      (annotations.arrows.length > 0 ||
+        annotations.highlights.length > 0 ||
+        annotations.circles.length > 0 ||
+        (annotations.ghostArrows?.length ?? 0) > 0));
 
   if (!hasContent) return null;
 
-  // Collect all arrows: move arrows first, then model annotations
-  const allArrows: { from: string; to: string; stroke: string; opacity: number; width: number; key: string }[] = [];
+  // Collect all arrows: move arrows first, then model annotations,
+  // then ghost arrows (with dashed styling).
+  const allArrows: {
+    from: string;
+    to: string;
+    stroke: string;
+    opacity: number;
+    width: number;
+    dashed?: boolean;
+    key: string;
+  }[] = [];
 
   // Move arrows (player-colored, thicker)
   for (let i = 0; i < moveArrows.length; i++) {
@@ -96,6 +109,24 @@ function AnnotationOverlay({
         opacity: 0.85,
         width: 4,
         key: `anno-arrow-${a.from}-${a.to}-${i}`,
+      });
+    }
+  }
+
+  // Ghost arrows — alternatives the lesson is DISCUSSING but not
+  // playing. Dashed + lower opacity so they read as "what could have
+  // happened" rather than the actual move.
+  if (annotations?.ghostArrows) {
+    for (let i = 0; i < annotations.ghostArrows.length; i++) {
+      const a = annotations.ghostArrows[i];
+      allArrows.push({
+        from: a.from,
+        to: a.to,
+        stroke: a.color,
+        opacity: 0.5,
+        width: 3,
+        dashed: true,
+        key: `ghost-arrow-${a.from}-${a.to}-${i}`,
       });
     }
   }
@@ -184,6 +215,7 @@ function AnnotationOverlay({
             stroke={arrow.stroke}
             strokeWidth={arrow.width}
             strokeLinecap="round"
+            strokeDasharray={arrow.dashed ? '6 5' : undefined}
             markerEnd={`url(#${markerId}-${arrow.stroke})`}
             opacity={arrow.opacity}
           />

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -1,15 +1,18 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Chess } from 'chess.js';
 import { useTournamentStore } from '../store/tournamentStore';
 import { useSettingsStore } from '../store/settingsStore';
 import { getBroadcastConfig } from '../app/broadcastConfig';
 import { exportBridge } from '../app/exportBridge';
 import { getEpisode, DEFAULT_EPISODE_ID } from '../episodes';
+import type { MoveTangent } from '../episodes/types';
 import { TournamentProgress } from './TournamentProgress';
 import { BroadcastLayout } from './BroadcastLayout';
 import { getActiveAudioNarrationQueue, runWhenAudioNarrationQueueAvailable, type NarrationMove } from '../tts/audio-queue';
 import { createRenderPlanFromPgn, type RenderPlan } from '../production/renderPlan';
-import { parseSinglePgn } from '../pgn/parser';
-import type { BoardAnnotations } from '../utils/board-annotations';
+import { parseSinglePgn, type PgnMove } from '../pgn/parser';
+import type { BoardAnnotations, GhostArrow } from '../utils/board-annotations';
+import { GHOST_ARROW_COLORS } from '../utils/board-annotations';
 
 /**
  * BroadcastView — the chrome-free, auto-playing layout used by the
@@ -340,6 +343,27 @@ export function BroadcastView() {
   const lastMove = computeLastMove(activeGameState);
   const commentaryEntries = computeCommentaryEntries(activeGameState, commentaryLog);
   const episode = config.episodeId ? getEpisode(config.episodeId) : undefined;
+
+  // Resolve per-ply ghost arrows from the episode's moveTangents.
+  // Pure function of (pgnMoves, moveTangents) so useMemo is enough —
+  // no effect, no re-resolution mid-capture.
+  const tangentsByPly = useMemo(
+    () => resolveTangentGhostArrows(pgnMoves, episode?.moveTangents ?? []),
+    [pgnMoves, episode?.moveTangents],
+  );
+
+  // Merge ghost arrows for the currently-narrated ply into the
+  // BoardAnnotations flowing to the layout. narrationMoveIndex is
+  // 0-indexed; ply is 1-indexed (ply = narrationMoveIndex + 1).
+  // Outside narration (intro / outro) narrationMoveIndex < 0 and no
+  // ghost arrows are shown.
+  const effectiveAnnotations = useMemo<BoardAnnotations | undefined>(() => {
+    const currentGhosts = narrationMoveIndex >= 0 ? tangentsByPly.get(narrationMoveIndex + 1) : undefined;
+    if (!currentGhosts || currentGhosts.length === 0) return narrationAnnotations;
+    const base: BoardAnnotations = narrationAnnotations ?? { arrows: [], highlights: [], circles: [] };
+    return { ...base, ghostArrows: currentGhosts };
+  }, [narrationAnnotations, narrationMoveIndex, tangentsByPly]);
+
   return (
     <>
       <div style={{ position: 'fixed', top: -10000, left: 0, width: 0, height: 0, overflow: 'hidden', pointerEvents: 'none' }} aria-hidden>
@@ -362,12 +386,54 @@ export function BroadcastView() {
         lastMove={lastMove}
         narrationMoveIndex={narrationMoveIndex}
         narrationSquares={narrationSquares}
-        narrationAnnotations={narrationAnnotations}
+        narrationAnnotations={effectiveAnnotations}
         narrationArrows={narrationArrows}
         pgnMoves={pgnMoves}
       />
     </>
   );
+}
+
+/**
+ * Resolve each tangent's SAN against the board position BEFORE its
+ * ply was played, returning a Map<ply, GhostArrow[]> for fast lookup
+ * during render. Invalid tangents (unparseable SAN, ply out of range)
+ * are silently dropped — they're authored content, the smoke capture
+ * is the QA loop.
+ */
+function resolveTangentGhostArrows(
+  pgnMoves: PgnMove[],
+  tangents: MoveTangent[],
+): Map<number, GhostArrow[]> {
+  const byPly = new Map<number, GhostArrow[]>();
+  for (const t of tangents) {
+    if (t.ply < 1 || t.ply > pgnMoves.length) continue;
+    // FEN BEFORE the move at this ply: starting position if ply 1,
+    // otherwise PgnMove.fen of the previous ply (which is the FEN
+    // AFTER the previous move = BEFORE the current move).
+    const fenBefore = t.ply === 1
+      ? 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+      : pgnMoves[t.ply - 2]?.fen;
+    if (!fenBefore) continue;
+    try {
+      const chess = new Chess(fenBefore);
+      const move = chess.move(t.san);
+      if (!move) continue;
+      const arrow: GhostArrow = {
+        from: move.from,
+        to: move.to,
+        color: GHOST_ARROW_COLORS[t.category],
+        category: t.category,
+        san: t.san,
+      };
+      const existing = byPly.get(t.ply);
+      if (existing) existing.push(arrow);
+      else byPly.set(t.ply, [arrow]);
+    } catch {
+      // Bad SAN — drop silently. Author's bug, surfaces in QA.
+    }
+  }
+  return byPly;
 }
 
 function computeLastMove(gameState: import('../engine/types').GameState | null): { from: string; to: string } | undefined {

--- a/src/episodes/italian_game_lesson/index.ts
+++ b/src/episodes/italian_game_lesson/index.ts
@@ -1,8 +1,42 @@
-import type { Episode } from '../types';
+import type { Episode, MoveTangent } from '../types';
 import { ITALIAN_GAME_LESSON_PGN } from './pgn';
 import { ITALIAN_GAME_LESSON_COMMENTATOR } from './commentator';
 import { ITALIAN_GAME_VARIATIONS } from './variations';
 import { ITALIAN_GAME_EXPORT } from './exports';
+
+const ITALIAN_GAME_BOOK_STANDARD = [
+  "Italian Game book standard.",
+  "White's goal: develop knights before bishops, place the king's bishop on c4 (aiming at f7), castle early, and choose between the classical c3-d4 break (Möller, romantic style) and the modern d3 quiet system (slow strategic maneuver).",
+  "Black's goal: mirror development with Nc6 + Bc5 (Giuoco Piano) or play more dynamically with Nf6 (Two Knights), keep the king safe on g8, and time ...d6 / ...a6 / ...h6 to neutralize White's bishop pressure.",
+  "Holding lines: both sides develop pieces toward the center, neither commits to a wing attack early, and either side that breaks the Italian's slow buildup tempo (premature pawn pushes, leaving f7/f2 weak) hands the initiative to the other.",
+  "Common pitfalls: blundering the f7-pawn to a knight or bishop, playing Bb6 too soon and getting hit by Nxe5/d5, or capturing with the wrong pawn structure after Bxe6 fxe6.",
+].join(' ');
+
+// POC tangents — three illustrative alternatives along the Italian
+// Game teaching line. Each ghost arrow appears for the duration of
+// the matching ply's commentary, then clears with the next move.
+// All SANs verified legal against the main PGN's position before
+// the ply they apply to.
+const ITALIAN_GAME_TANGENTS: MoveTangent[] = [
+  {
+    ply: 7, // White's 4th move (c3 in main)
+    san: 'd4',
+    category: 'engine_refutation',
+    note: 'Instead of c3, White could try d4 directly — but exd4 transposes the Italian into Scotch Game territory and concedes the central tension.',
+  },
+  {
+    ply: 9, // White's 5th move (d3 in main)
+    san: 'Ng5',
+    category: 'student_mistake',
+    note: 'Ng5 looks aggressive (the Two Knights idea against f7), but here Black has ...d5! and the knight is offside — d3 quietly is correct.',
+  },
+  {
+    ply: 11, // White's 6th move (O-O in main)
+    san: 'Bxf7+',
+    category: 'student_mistake',
+    note: 'Bxf7+ is the famous Italian sacrifice pattern but here it loses the bishop outright — ...Kxf7 and White has no follow-up. Castle first.',
+  },
+];
 
 /**
  * The Italian Game — opening lesson.
@@ -24,6 +58,8 @@ export const ITALIAN_GAME_LESSON_EPISODE: Episode = {
   source: 'agent_generated',
   pgn: ITALIAN_GAME_LESSON_PGN,
   commentator: ITALIAN_GAME_LESSON_COMMENTATOR,
+  bookStandard: ITALIAN_GAME_BOOK_STANDARD,
+  moveTangents: ITALIAN_GAME_TANGENTS,
   exports: ITALIAN_GAME_EXPORT,
 };
 

--- a/src/episodes/types.ts
+++ b/src/episodes/types.ts
@@ -57,10 +57,79 @@ export interface Episode {
    * set the lesson context use the teacher prompt builder instead.
    */
   historicalContext?: string;
+  /**
+   * The opening's BOOK STANDARD — what each side is trying to achieve,
+   * what counts as a successful opening for each color, and the
+   * principles that "hold the line" (i.e. the moves and ideas considered
+   * mainstream good play). Track A only.
+   *
+   * Read into the lesson commentator's system prompt and stated near
+   * the top of the lesson so the viewer knows the WIN CONDITION the
+   * opening targets before move-by-move teaching begins.
+   *
+   * Example: "Ruy Lopez book standard — White: develop, pin the c6
+   * knight, hold the long Spanish bishop diagonal, play c3/d4 at the
+   * right moment. Black: free the position with ...a6/...b5/...d6,
+   * solve the c8-bishop, time the ...c5 break. Each side wants a
+   * playable middlegame with their own structural priorities intact."
+   */
+  bookStandard?: string;
+  /**
+   * Per-move tangents — ALTERNATIVE moves the lesson can teach about
+   * (typically blunders or sub-variations) WITHOUT actually playing
+   * them on the board. The board renders these as ghosted arrows
+   * during the narration of the relevant ply, so the viewer sees
+   * "what could have happened" while the lesson stays on the main line.
+   * Track A only.
+   *
+   * The commentator's prompt for each move surfaces the matching
+   * tangents so it can weave them into narration ("If Black plays Nf6
+   * here, that's a typical student mistake because…").
+   */
+  moveTangents?: MoveTangent[];
   /** Export configuration. Present once the episode is planned for export. */
   exports?: EpisodeExportConfig;
   /** Published references (e.g. YouTube URLs). Workspace-tracked. */
   published?: EpisodePublishedRef[];
+}
+
+/**
+ * A per-move ALTERNATIVE move shown as a ghost arrow on the board while
+ * the lesson narrates the main move. Doesn't replay the line — the
+ * board stays on the main PGN, but the alternative move is rendered
+ * with a translucent / dashed arrow so the viewer sees what was
+ * considered.
+ *
+ * `category` drives the arrow's styling so different kinds of
+ * alternatives are visually distinguishable.
+ */
+export interface MoveTangent {
+  /**
+   * Which move in the main PGN this tangent applies to. 1-indexed ply
+   * counter: 1 = White's first move, 2 = Black's first move, etc.
+   * The tangent shows on the board while THIS move's commentary plays.
+   */
+  ply: number;
+  /**
+   * The alternative move in SAN (e.g. "Nf6"). Resolved at render time
+   * to from/to squares against the board's position just BEFORE the
+   * main move at this ply was played.
+   */
+  san: string;
+  /**
+   * Category — drives the ghost arrow's color / style:
+   *   'student_mistake'    — common club-level error
+   *   'move_order_trap'    — looks fine but loses to a known trap
+   *   'engine_refutation'  — natural-looking move that engines refute
+   *   'historical_blunder' — a real-game blunder by a named player
+   */
+  category: 'student_mistake' | 'move_order_trap' | 'engine_refutation' | 'historical_blunder';
+  /**
+   * One-line teaching note for the commentator. Read into the prompt
+   * for this ply so the LLM can mention the tangent ("if Black plays X
+   * here, that's because <note>").
+   */
+  note: string;
 }
 
 /** Provenance of the PGN that backs the Episode. */

--- a/src/utils/board-annotations.ts
+++ b/src/utils/board-annotations.ts
@@ -42,6 +42,25 @@ export interface BoardAnnotations {
   arrows: AnnotationArrow[];
   highlights: AnnotationHighlight[];
   circles: AnnotationCircle[];
+  /**
+   * Optional ghost (alternative) arrows — moves the lesson DIDN'T play
+   * but is currently discussing (typical blunder, engine refutation,
+   * move-order trap). Rendered as dashed + low-opacity arrows so they
+   * read as "what could have happened" rather than the actual move.
+   * Authored per-episode via Episode.moveTangents; not produced by
+   * commentary parsing.
+   */
+  ghostArrows?: GhostArrow[];
+}
+
+/**
+ * A ghost arrow with a category that drives its styling. See
+ * MoveTangent in src/episodes/types.ts for the data model.
+ */
+export interface GhostArrow extends AnnotationArrow {
+  category: 'student_mistake' | 'move_order_trap' | 'engine_refutation' | 'historical_blunder';
+  /** SAN of the move being ghosted, used for hover/debug labelling. */
+  san?: string;
 }
 
 export type SemanticCueKind =
@@ -77,7 +96,15 @@ export interface AnnotationParseOptions {
   includePassiveSquares?: boolean;
 }
 
-export const EMPTY_ANNOTATIONS: BoardAnnotations = { arrows: [], highlights: [], circles: [] };
+export const EMPTY_ANNOTATIONS: BoardAnnotations = { arrows: [], highlights: [], circles: [], ghostArrows: [] };
+
+/** Standard color per ghost-arrow category. */
+export const GHOST_ARROW_COLORS: Record<GhostArrow['category'], string> = {
+  student_mistake: 'rgba(255, 23, 68, 0.55)',     // red — typical club error
+  move_order_trap: 'rgba(255, 145, 0, 0.55)',     // orange — trap line
+  engine_refutation: 'rgba(0, 229, 255, 0.55)',   // cyan — computer refutation
+  historical_blunder: 'rgba(180, 130, 255, 0.55)',// purple — historical reference
+};
 
 const TAG_PATTERN = /\[(?:arrow|highlight|circle|move)\s+[^\]]+\]/gi;
 const RESIDUAL_TAG_PATTERN = /\[\/?(?:arrow|highlight|circle|move)\b[^\]]*\]/gi;


### PR DESCRIPTION
## Summary

Two new data hooks for the lesson commentator, plus the rendering pipeline that makes one of them visible on the board.

### bookStandard (new \`Episode\` field)

Each Track A lesson can now declare what the opening is **actually trying to do** — win conditions per side, holding lines (the moves and ideas that constitute book play), and common pitfalls. Surfaced into the commentator's system prompt so the lesson opens with the framing the user asked for: \"what we want out of an opening and what is the book standards for those that hold lines.\"

### moveTangents + ghost arrows (new \`Episode\` field + rendering)

A per-ply list of **alternative moves** rendered as dashed, translucent arrows on the board while the corresponding move is being narrated. The board stays on the main PGN — the tangent is \"what could have happened\" not a branch replay.

| Category | Color | Use |
|---|---|---|
| \`student_mistake\` | red | common club-level errors |
| \`move_order_trap\` | orange | looks fine but loses to a known trap |
| \`engine_refutation\` | cyan | natural-looking moves computers refute |
| \`historical_blunder\` | purple | real-game blunders by named players |

## Italian Game POC

Three tangents along the Giuoco Piano main line, all SANs validated legal against their target position:

| Ply | Tangent | Category | Why it's interesting |
|---|---|---|---|
| 7 (4.c3) | \`d4\` | engine_refutation | Transposes Italian into Scotch territory |
| 9 (5.d3) | \`Ng5\` | student_mistake | Two Knights attack doesn't work with Bc5 |
| 11 (6.O-O) | \`Bxf7+\` | student_mistake | Famous sac pattern, just loses the bishop |

## Pipeline

- [\`board-annotations.ts\`](src/utils/board-annotations.ts) — \`BoardAnnotations.ghostArrows\` + \`GhostArrow\` type with \`category\` field and \`GHOST_ARROW_COLORS\` palette
- [\`Board.tsx\`](src/components/Board.tsx) — renders ghost arrows in \`AnnotationOverlay\` with \`strokeDasharray\`, opacity 0.5
- [\`BroadcastView.tsx\`](src/components/BroadcastView.tsx) — \`resolveTangentGhostArrows\` parses each tangent's SAN against the position before its ply (using \`PgnMove.fen\` of the previous ply), \`useMemo\` builds a \`Map<ply, GhostArrow[]>\`, then merges current-ply ghosts into the \`BoardAnnotations\` flowing to the layout based on \`narrationMoveIndex\`

## Test plan

- [x] Typecheck clean
- [x] Italian tangent SANs validate legal vs main PGN positions
- [ ] Smoke capture: confirm ghost arrows render dashed at the right ply
- [ ] Visual audit: ghost-arrow colors readable at portrait + landscape

## Follow-up

Integrate \`moveTangents\` into the commentator's per-move prompt so the LLM actively narrates the alternative (\"If Black plays X here…\") while its ghost arrow is on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)