### PR TITLE
fix(mp4-export): upload-grade ffmpeg encoding for text-heavy content

### DIFF
--- a/scripts/lib/export/compressDeadAir.ts
+++ b/scripts/lib/export/compressDeadAir.ts
@@ -28,6 +28,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { mkdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { registerPid } from './processRegistry';
+import { VIDEO_ENCODE_ARGS, AUDIO_ENCODE_ARGS } from './ffmpegCompose';
 
 export interface CompressDeadAirOptions {
   /** Input MP4 (with audio) produced by the first compose pass. */
@@ -187,6 +188,9 @@ export async function compressDeadAir(opts: CompressDeadAirOptions): Promise<Com
     throw new Error('[dead-air] All audio detected as silence — refusing to produce an empty MP4.');
   }
   const filter = buildTrimConcatFilter(keeps);
+  // Re-encode with the same upload-grade settings as the first compose
+  // pass. The trim+concat filter forces a re-encode (no -c copy
+  // possible), so quality settings here determine the FINAL upload.
   const args = [
     '-y',
     '-i',
@@ -197,20 +201,8 @@ export async function compressDeadAir(opts: CompressDeadAirOptions): Promise<Com
     '[outv]',
     '-map',
     '[outa]',
-    '-c:v',
-    'libx264',
-    '-pix_fmt',
-    'yuv420p',
-    '-preset',
-    'veryfast',
-    '-crf',
-    '20',
-    '-movflags',
-    '+faststart',
-    '-c:a',
-    'aac',
-    '-b:a',
-    '160k',
+    ...VIDEO_ENCODE_ARGS,
+    ...AUDIO_ENCODE_ARGS,
     opts.outputPath,
   ];
   await runFfmpeg(opts.ffmpegPath, args);

--- a/scripts/lib/export/ffmpegCompose.ts
+++ b/scripts/lib/export/ffmpegCompose.ts
@@ -33,17 +33,54 @@ export interface ComposeOptions {
 }
 
 /**
- * Run ffmpeg to encode the frame sequence into a playable MP4.
+ * Upload-grade H.264 encoder args, shared between the compose pass and
+ * the dead-air re-encode. The previous CRF-20 / veryfast setup
+ * produced 0.1–0.5 Mbps streams for mostly-static board content, which
+ * smeared text and thin board lines once YouTube re-encoded them.
  *
- * Args breakdown:
- *   -framerate <rate>         expected input frame rate
- *   -i frame_%08d.jpg         glob of JPEG inputs
- *   -c:v libx264              widely-supported H.264 encoder
- *   -pix_fmt yuv420p          required for QuickTime / browser playback
- *   -movflags +faststart      enables streaming (metadata at file head)
- *   -preset veryfast          balance speed vs. file size; iteration friendly
- *   -crf 20                   visually transparent quality (good for code text)
- *   -y                        overwrite output without prompting
+ * Target: 1080p text-heavy content that survives one round of YouTube
+ * transcode without breaking down. Both landscape (1920×1080) and
+ * portrait (1080×1920) carry ~2M pixels per frame, so the same target
+ * bitrate works for both.
+ *
+ *   -b:v 8M -maxrate 10M -bufsize 16M  8 Mbps target with headroom
+ *   -preset slow                       better compression at same bitrate
+ *                                      (trades encode time for quality)
+ *   -tune stillimage                   x264 mode optimized for static
+ *                                      text/diagram content
+ *   -profile:v high -level 4.1         standard 1080p H.264 profile
+ *   -pix_fmt yuv420p                   QuickTime / browser compat
+ *   -movflags +faststart               metadata at file head for streaming
+ */
+const VIDEO_ENCODE_ARGS = [
+  '-c:v', 'libx264',
+  '-preset', 'slow',
+  '-tune', 'stillimage',
+  '-profile:v', 'high',
+  '-level', '4.1',
+  '-pix_fmt', 'yuv420p',
+  '-b:v', '8M',
+  '-maxrate', '10M',
+  '-bufsize', '16M',
+  '-movflags', '+faststart',
+];
+
+/**
+ * AAC audio encoder args. 192 kbps stereo is the upper end of what
+ * YouTube accepts without re-encoding for AAC sources — keeps the
+ * narration crisp through the re-transcode.
+ */
+const AUDIO_ENCODE_ARGS = [
+  '-c:a', 'aac',
+  '-b:a', '192k',
+  '-ar', '48000',
+];
+
+export { VIDEO_ENCODE_ARGS, AUDIO_ENCODE_ARGS };
+
+/**
+ * Run ffmpeg to encode the frame sequence into a playable MP4.
+ * See VIDEO_ENCODE_ARGS above for the codec settings rationale.
  */
 export async function composeMp4(options: ComposeOptions): Promise<void> {
   await mkdir(path.dirname(options.outputPath), { recursive: true });
@@ -55,22 +92,10 @@ export async function composeMp4(options: ComposeOptions): Promise<void> {
     '-i',
     path.join(options.frameDir, 'frame_%08d.jpg'),
     ...(hasAudio ? ['-i', options.audioPath as string] : []),
-    '-c:v',
-    'libx264',
-    '-pix_fmt',
-    'yuv420p',
-    '-movflags',
-    '+faststart',
-    '-preset',
-    'veryfast',
-    '-crf',
-    '20',
+    ...VIDEO_ENCODE_ARGS,
     ...(hasAudio
       ? [
-          '-c:a',
-          'aac',
-          '-b:a',
-          '160k',
+          ...AUDIO_ENCODE_ARGS,
           // Map: video from input 0, audio from input 1.
           '-map',
           '0:v:0',


### PR DESCRIPTION
## Summary

The current encodes ship at 0.1–0.5 Mbps video. That's way too thin for text- and map-heavy content that will be re-encoded by YouTube. Switching both ffmpeg passes (compose + dead-air re-encode) to upload-grade settings.

## The problem

| File | Resolution | Length | Total bitrate | Video bitrate |
|---|---|---|---|---|
| \`italian_evans_gambit_tight.mp4\` | 1080×1920 | 9:16 | ~0.28 Mbps | ~0.12 Mbps |
| \`italian_game_lesson_tight.mp4\` | 1920×1080 | 10:14 | ~0.26 Mbps | ~0.10 Mbps |

\`-crf 20 -preset veryfast\` on mostly-static board content undershoots target bitrate dramatically — visually fine on the file as-is, but YouTube re-encodes any upload, and the thin text + thin board lines smear badly through that pass.

## Changes

Settings applied to **both** the compose pass and the dead-air re-encode (the trim+concat filter forces re-encode anyway; drift between the two passes would mean the \`_tight.mp4\` quietly re-loses quality):

| Arg | Value | Why |
|---|---|---|
| \`-b:v\` | 8M | 1080p text-heavy target |
| \`-maxrate / -bufsize\` | 10M / 16M | ~25% peak headroom |
| \`-preset\` | slow | better compression at same bitrate |
| \`-tune\` | stillimage | x264 mode for static text/diagrams |
| \`-profile:v / -level\` | high / 4.1 | standard 1080p H.264 |
| \`-c:a / -b:a / -ar\` | aac / 192k / 48000 | crisp narration through YT re-encode |

Encode args extracted into shared \`VIDEO_ENCODE_ARGS\` / \`AUDIO_ENCODE_ARGS\` constants in [\`ffmpegCompose.ts\`](scripts/lib/export/ffmpegCompose.ts) so the dead-air re-encode and the compose pass can't drift.

## Expected outcome at 8 Mbps

| File | Was | Now |
|---|---|---|
| 10-min long-form | ~17 MB | ~600 MB |
| 9-min portrait | ~24 MB | ~540 MB |

Bigger files. The upload-once / play-many-times tradeoff is the right one for content that needs to survive YouTube's re-encode.

## Test plan

- [x] Typecheck clean
- [ ] Re-capture \`italian_evans_gambit\` and confirm bitrate ≥ 6 Mbps via ffprobe
- [ ] Upload one to YouTube and verify the text + board lines stay crisp after the platform re-encode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated video encoding parameters for export operations
  * Updated audio encoding parameters for export operations
  * Unified encoding settings across re-encoding passes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->