### PR TITLE
fix(export): orphan viewport ref + batch path encoding

### DIFF
--- a/scripts/export-chess-mp4.ts
+++ b/scripts/export-chess-mp4.ts
@@ -402,7 +402,7 @@ async function main(): Promise<void> {
 
   console.log(`[export] ${input.title}`);
   console.log(
-    `[export]   ${initialPlan.fullEpisode.timeline.length} segments, planned ${(initialPlan.fullEpisode.range.endMs / 1000).toFixed(1)} s, viewport ${viewport.width}x${viewport.height}`,
+    `[export]   ${initialPlan.fullEpisode.timeline.length} segments, planned ${(initialPlan.fullEpisode.range.endMs / 1000).toFixed(1)} s`,
   );
   if (flags.fastMode) console.log('[export]   --fast (lower JPEG quality)');
   if (flags.previewDurationMs) console.log(`[export]   --preview=${flags.previewDurationMs / 1000} s`);

--- a/scripts/export-openings-series.mjs
+++ b/scripts/export-openings-series.mjs
@@ -25,6 +25,7 @@ import { spawn } from 'node:child_process';
 import { mkdir, appendFile, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const EPISODES = [
   'italian_game_lesson',
@@ -34,7 +35,7 @@ const EPISODES = [
   'qgd_orthodox_lesson',
 ];
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname).replace(/^\/([A-Z]:)/, '$1'), '..');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const logRoot = path.join(repoRoot, 'exports', '_batch-logs');
 
 function stamp() {


### PR DESCRIPTION
Two bugs blocking the openings batch run. See commit body.