### PR TITLE
feat(broadcast): multi-modal layout + London rich authoring

### DIFF
--- a/docs/design-branch-playback.md
+++ b/docs/design-branch-playback.md
@@ -1,0 +1,248 @@
+# Design: Instructor Board Control (Branch Playback)
+
+Status: **Design — pre-implementation**
+Owner: next PR after London reshoot ships
+Date: 2026-05-27
+
+## Goal
+
+Let a lesson **pause, rewind, play an alternative line on the actual board, then return to the main line**. Per the user:
+
+> "we need the ability for the instructor to control board state with more granularity. to roll back the game and explore different ideas, etc"
+
+This is the natural extension of `moveTangents` (ghost arrows) from PR #58: instead of just *showing* the alternative as a dashed arrow, the board actually *plays* it and *recovers*.
+
+## Relationship to existing features
+
+| Feature | Behavior |
+|---|---|
+| `moveTangents` (PR #58) | Dashed arrow on board during current ply's narration. Board state never changes. |
+| **Branch playback (this PR)** | Board state DOES change. Plays N moves of a branch, then snaps back to where the main line was. |
+| Whiteboard scenes (PR #68) | Board fades out; full-frame educational slate replaces it. |
+
+A "scene" is the unifying concept: a moment where the lesson pauses for a focused interlude. Whiteboards are visual scenes; branch playback is board-state scenes.
+
+## Schema
+
+```ts
+// New on Episode:
+boardBranches?: BoardBranch[];
+
+interface BoardBranch {
+  /**
+   * 1-indexed ply AFTER which the branch plays. The lesson pauses
+   * after move N completes, the board rewinds to `fromPly` (often
+   * just `ply` itself), then plays the branch moves.
+   */
+  ply: number;
+  /**
+   * How far to rewind before playing the branch. Default = ply
+   * (= same position the main line just reached, no rewind).
+   * For "what if Black had played differently 2 moves ago?" use
+   * fromPly = ply - 2.
+   */
+  fromPly?: number;
+  /**
+   * SAN move sequence to play from fromPly. Validated at startup
+   * against the main PGN's position.
+   */
+  branchMoves: string[];
+  /**
+   * One-line educational topic the commentator should narrate
+   * during the branch. Injected into the prompt so the audio
+   * matches what the board is doing.
+   */
+  narrationCue: string;
+  /**
+   * After playing the branch, snap back to this ply of the main
+   * line. Default = the ply the main line was at when the branch
+   * started (= no skip). For "play 4 moves of the trap line, then
+   * skip ahead 2 moves in the main line" use returnToPly = ply + 2.
+   */
+  returnToPly?: number;
+  /**
+   * Wall-clock delay between each branch move (ms) so the viewer
+   * can follow. Default 1500. Faster than main-line moveDelayMs
+   * because the branch is dense educational content.
+   */
+  branchMoveDelayMs?: number;
+  /**
+   * Title shown briefly during the branch (e.g. "Blunder Line: 7.h3
+   * d5! and Black wins material"). Optional.
+   */
+  title?: string;
+}
+```
+
+## Visual sequence
+
+```
+[main line]  ... move N played, commentary plays ...
+              ↓
+[transition] board fades 50%, "BRANCH: <title>" banner slides in
+              ↓
+[rewind]     pieces animate back to fromPly position (250-500 ms ease)
+              ↓
+[branch]     branchMoves[0], branchMoves[1], ... play with branchMoveDelayMs
+              accompanying narration from the commentator (narrationCue)
+              ↓
+[return]     pieces animate to returnToPly position
+              ↓
+[resume]     banner slides out, board returns to 100% opacity
+              ↓
+[main line]  next move of the main line plays
+```
+
+## Engine changes
+
+Currently the replay runtime is fed a single linear PGN via `startReplay(pgnText)`. It plays moves sequentially with a `replayPaceCheck` callback to coordinate narration.
+
+New mechanism: a **branch director** that sits between the runtime and the playback loop.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  GameRuntime (replay mode)                              │
+│                                                          │
+│  Existing flow:                                         │
+│    PGN moves → playMove → state → MoveApplied event     │
+│                                                          │
+│  New flow:                                              │
+│    [main line move N] → check branch director          │
+│      ├─ no branch at ply N → continue as before        │
+│      └─ branch at ply N → pause main, run branch,      │
+│                            then resume main             │
+└─────────────────────────────────────────────────────────┘
+```
+
+The branch director is implemented at the **runtime layer**, not in the replay-pace callback, so the state machine stays clean.
+
+### State changes
+
+`GameRuntime` needs:
+- `inBranch: boolean` — gates main-line advancement during a branch
+- `branchStack: BranchFrame[]` — supports nested branches (probably YAGNI for v1)
+- `mainLineFen: string` — saved position to restore after the branch
+- Event types: `BranchStarted`, `BranchMoveApplied`, `BranchEnded`
+
+### Why not just emit MoveApplied for branch moves?
+
+Because the consumers (BroadcastLayout, recent moves panel, commentary log) would treat the branch moves as part of the main game history. The lesson's "Move 8" wouldn't make sense if a branch played 4 moves between moves 7 and 8.
+
+`BranchMoveApplied` is a sibling event with its own move counter. The reducer:
+- Keeps `mainHistory: MoveRecord[]` (unchanged)
+- Adds `currentBranchMoves: MoveRecord[]` (empty when not in a branch)
+- `displayedFen` switches to `currentBranchFen` while in branch, then back
+
+### Position management
+
+```ts
+// Pseudocode for the runtime branch director:
+async function executeBranch(branch: BoardBranch, currentPly: number) {
+  const mainFen = currentFen;
+  const mainEvtLog = events;
+
+  // Rewind: load FEN before `fromPly` (or current if fromPly == ply)
+  const rewindTarget = branch.fromPly ?? currentPly;
+  if (rewindTarget < currentPly) {
+    const fen = pgnMoves[rewindTarget - 1].fen;  // FEN AFTER move rewindTarget
+    emit({ type: 'BranchStarted', payload: { fromPly: rewindTarget, title: branch.title } });
+    emit({ type: 'BranchPositionSet', payload: { fen } });
+  } else {
+    emit({ type: 'BranchStarted', payload: { fromPly: currentPly, title: branch.title } });
+  }
+
+  // Play each branch move
+  const chess = new Chess(fen);
+  for (const san of branch.branchMoves) {
+    const move = chess.move(san);
+    emit({ type: 'BranchMoveApplied', payload: { san, from: move.from, to: move.to, fen: chess.fen() } });
+    await sleep(branch.branchMoveDelayMs ?? 1500);
+    await waitForNarrationGate();  // same gating as main line
+  }
+
+  // Restore main line position
+  const returnTarget = branch.returnToPly ?? currentPly;
+  const returnFen = returnTarget === 0
+    ? STARTING_FEN
+    : pgnMoves[returnTarget - 1].fen;
+  emit({ type: 'BranchEnded', payload: { resumeFen: returnFen, resumePly: returnTarget } });
+}
+```
+
+## Commentator integration
+
+The branch needs narration that matches what the board is doing. The commentator queue gets a new entry kind:
+
+```ts
+// In CommentaryQueue:
+generateBranchCommentary(spec: {
+  branchMoves: string[];
+  narrationCue: string;
+  position: string;  // FEN at branch start
+}): Promise<void>;
+```
+
+This produces a single narrated block covering all branch moves (not move-by-move). The viewer hears one continuous explanation while the board plays the branch.
+
+Alternative (more work, better quality): generate per-branch-move commentary like the main line. Defer to v2.
+
+## Authoring example: Italian Game
+
+```ts
+const ITALIAN_BOARD_BRANCHES: BoardBranch[] = [
+  {
+    ply: 11,  // After 6.O-O (White's 6th move)
+    fromPly: 11,
+    title: "What if White played Bxf7+ instead?",
+    branchMoves: ['Bxf7+', 'Kxf7', 'Ng5+', 'Kg8', 'Qh5', 'g6'],
+    returnToPly: 11,
+    narrationCue:
+      "Take 4 moves to show what happens if White sacrifices the bishop on f7 here. Note that Black's king walks but White has no follow-up — Black is just up a piece.",
+    branchMoveDelayMs: 1800,
+  },
+  // ...
+];
+```
+
+The screen sequence:
+1. Main line: 6.O-O O-O is played, commentary covers the castle.
+2. Pause; banner: "BRANCH: What if White played Bxf7+ instead?"
+3. Board rewinds to position after 6.O-O (no rewind needed here — same position).
+4. Branch plays: 6.Bxf7+ Kxf7 7.Ng5+ Kg8 8.Qh5 g6 (with branch commentary playing).
+5. Board snaps back to position after 6.O-O O-O.
+6. Banner clears; commentary resumes with 7.Nbd2 (next main-line move).
+
+## Test plan
+
+1. **Smoke**: 1 branch on Italian Game at ply 11 (Bxf7+ trap line). Verify visually that the board rewinds, plays the branch, and returns.
+2. **No-flag default**: episodes WITHOUT `boardBranches` capture identically to current behavior.
+3. **With-flag** (consider adding `?branches=1` to opt in for v1 captures): same episodes with branches authored produce a longer video with the branches.
+4. **Multiple branches**: 2 branches in the same episode, no overlap.
+5. **Nested handling**: skip for v1; document as future work.
+
+## Estimated scope
+
+| Piece | LoC | Risk |
+|---|---|---|
+| Schema + types | ~80 | Low |
+| Runtime branch director | ~250 | High (touches GameRuntime state machine) |
+| Event types + reducer | ~120 | Medium |
+| BroadcastLayout — branch banner + faded board | ~80 | Low |
+| Commentator branch entry | ~150 | Medium (touches CommentaryQueue) |
+| Authoring on Italian (1-2 branches) | ~50 | Low |
+
+**Total: ~750 LoC, mostly engine.** ~2-3 days focused work.
+
+## Open questions
+
+1. **Branch-mode TTS pacing**: does narration drive the branch move advance (like main line), or does the branch play at its own fixed pace? Recommend: keep narration-gated for consistency.
+2. **Eval bar during branch**: show Stockfish eval of the branch position, or freeze at main-line eval? Recommend: show branch eval (it's part of the educational point — "see how the eval drops here").
+3. **Recent moves panel**: include branch moves, or only main-line moves? Recommend: branch moves shown with a "[BRANCH]" prefix, removed when branch ends.
+4. **What if the branch reaches checkmate?**: do we celebrate or just return? Recommend: pause briefly to acknowledge, then return.
+
+## Non-goals (v1)
+
+- **Nested branches**: a branch within a branch. Defer.
+- **Interactive branching**: viewer-driven choice of which branch to play. This is a published video, not a UI.
+- **PGN export of branches**: the rendered MP4 includes them; the PGN stays the main line. Defer authoring this if needed.
+- **Branch playback from the main app (non-broadcast)**: only ships behind the broadcast flag.

--- a/src/components/BroadcastLayout.tsx
+++ b/src/components/BroadcastLayout.tsx
@@ -22,6 +22,7 @@ import type { CommentaryEntry } from '../commentary/commentaryQueue';
 import type { NarrationMove } from '../tts/audio-queue';
 import type { BoardAnnotations } from '../utils/board-annotations';
 import type { PgnMove } from '../pgn/parser';
+import type { EpisodeChapter, KeyIdeasBlock, WhatToWatchBlock, FunFact } from '../episodes/types';
 
 interface BroadcastLayoutProps {
   gameState: GameState;
@@ -63,6 +64,16 @@ interface BroadcastLayoutProps {
    * looking up FENs by eventLog index is incorrect).
    */
   pgnMoves: PgnMove[];
+  /**
+   * Multi-modal sidebar content. When `chapters` is non-empty,
+   * landscape renders the 3-column multi-modal layout (board +
+   * caption/movelist column + ideas/watch column) with chapter
+   * header bar. Otherwise renders the legacy 2-column layout.
+   */
+  chapters?: EpisodeChapter[];
+  keyIdeas?: KeyIdeasBlock[];
+  whatToWatch?: WhatToWatchBlock[];
+  funFacts?: FunFact[];
 }
 
 /**
@@ -132,6 +143,10 @@ export function BroadcastLayout({
   narrationAnnotations,
   narrationArrows,
   pgnMoves,
+  chapters,
+  keyIdeas,
+  whatToWatch,
+  funFacts,
 }: BroadcastLayoutProps) {
   // The displayed board tracks the NARRATED move, not the runtime's
   // latest. During the intro (narrationMoveIndex < 0), the runtime
@@ -195,6 +210,68 @@ export function BroadcastLayout({
     [...commentaryEntries].reverse().find((e) => e.text)?.text ||
     '';
 
+  // Multi-modal: resolve the active chapter from the current ply.
+  // The "ply" for chapter-matching is 1-indexed and reflects which
+  // move the viewer is on (narrationMoveIndex + 1 when narrated,
+  // otherwise 0 = intro). A chapter is active from its `ply` up to
+  // the next chapter's `ply` (or forever for the last chapter).
+  const currentPly = narratedInfo ? narrationMoveIndex + 1 : 0;
+  const activeChapter = useMemo<EpisodeChapter | null>(() => {
+    if (!chapters || chapters.length === 0) return null;
+    const sorted = [...chapters].sort((a, b) => a.ply - b.ply);
+    let match: EpisodeChapter | null = null;
+    for (const ch of sorted) {
+      if (ch.ply <= currentPly) match = ch;
+      else break;
+    }
+    return match ?? sorted[0];
+  }, [chapters, currentPly]);
+  const activeChapterIndex = useMemo(() => {
+    if (!chapters || !activeChapter) return 0;
+    return chapters.findIndex((c) => c.ply === activeChapter.ply);
+  }, [chapters, activeChapter]);
+  const activeKeyIdeas = useMemo<string[] | null>(() => {
+    if (!activeChapter || !keyIdeas) return null;
+    return keyIdeas.find((b) => b.chapterPly === activeChapter.ply)?.ideas ?? null;
+  }, [activeChapter, keyIdeas]);
+  const activeWhatToWatch = useMemo<string | null>(() => {
+    if (!activeChapter || !whatToWatch) return null;
+    return whatToWatch.find((b) => b.chapterPly === activeChapter.ply)?.text ?? null;
+  }, [activeChapter, whatToWatch]);
+  // Full move list — every ply of the parsed PGN with the current
+  // ply highlighted. Pairs white+black moves into rows.
+  const fullMoveList = useMemo(() => {
+    const pairs: { num: number; white?: string; black?: string; whitePly?: number; blackPly?: number }[] = [];
+    for (let i = 0; i < pgnMoves.length; i++) {
+      const move = pgnMoves[i];
+      const ply = i + 1;
+      const turnNum = Math.ceil(ply / 2);
+      const last = pairs[pairs.length - 1];
+      if (move.color === 'w') {
+        pairs.push({ num: turnNum, white: move.san, whitePly: ply });
+      } else if (last && last.num === turnNum && last.white !== undefined) {
+        last.black = move.san;
+        last.blackPly = ply;
+      } else {
+        pairs.push({ num: turnNum, black: move.san, blackPly: ply });
+      }
+    }
+    return pairs;
+  }, [pgnMoves]);
+  // Fun fact rotator — picks the fact valid for currentPly that has
+  // rotated to "now". For v1 we slice by `floor(currentPly / 4)`
+  // so a new fact shows every ~4 plies (~2 minutes at lesson pace).
+  const activeFunFact = useMemo<FunFact | null>(() => {
+    if (!funFacts || funFacts.length === 0) return null;
+    const eligible = funFacts.filter(
+      (f) => (f.minPly ?? 0) <= currentPly && (f.maxPly ?? Infinity) >= currentPly,
+    );
+    if (eligible.length === 0) return null;
+    const slot = Math.floor(currentPly / 4) % eligible.length;
+    return eligible[slot];
+  }, [funFacts, currentPly]);
+  const useMultiModal = (chapters?.length ?? 0) > 0;
+
   if (orientation === 'short') {
     return <ShortLayout
       displayedFen={displayedFen}
@@ -209,6 +286,27 @@ export function BroadcastLayout({
       recentMoves={recentMoves}
       evalPct={evalPct}
       evalLabel={evalLabel}
+    />;
+  }
+  if (useMultiModal && activeChapter) {
+    return <MultiModalLayout
+      displayedFen={displayedFen}
+      lastMove={displayedLastMove}
+      narrationSquares={narrationSquares}
+      narrationAnnotations={narrationAnnotations}
+      narrationArrows={narrationArrows}
+      moveCounterText={moveCounterText}
+      liveCaption={liveCaption}
+      evalPct={evalPct}
+      evalLabel={evalLabel}
+      activeChapter={activeChapter}
+      activeChapterIndex={activeChapterIndex}
+      totalChapters={(chapters?.length ?? 0)}
+      activeKeyIdeas={activeKeyIdeas}
+      activeWhatToWatch={activeWhatToWatch}
+      fullMoveList={fullMoveList}
+      activePly={currentPly}
+      activeFunFact={activeFunFact}
     />;
   }
   return <FullLayout
@@ -240,6 +338,110 @@ interface LayoutSlotProps {
   recentMoves: { turn: number; white?: string; black?: string }[];
   evalPct: number;
   evalLabel: string;
+}
+
+interface MultiModalSlotProps {
+  displayedFen: string;
+  lastMove?: { from: string; to: string };
+  narrationSquares: string[];
+  narrationAnnotations?: BoardAnnotations;
+  narrationArrows: NarrationMove[];
+  moveCounterText: string;
+  liveCaption: string;
+  evalPct: number;
+  evalLabel: string;
+  activeChapter: EpisodeChapter;
+  activeChapterIndex: number;
+  totalChapters: number;
+  activeKeyIdeas: string[] | null;
+  activeWhatToWatch: string | null;
+  fullMoveList: { num: number; white?: string; black?: string; whitePly?: number; blackPly?: number }[];
+  activePly: number;
+  activeFunFact: FunFact | null;
+}
+
+/**
+ * 16:9 multi-modal landscape layout. Three columns:
+ *
+ *   board (~900px) | caption + move list (~500px) | ideas + watch (~500px)
+ *
+ * With a chapter header bar at the top showing CHAPTER N · title · subtitle
+ * and the move counter. Mirrors the multi-panel approach the user
+ * endorsed in their 2026-05-27 feedback (Codex's London frame): use
+ * the available horizontal space to surface key ideas, the running
+ * move list, and strategic guidance alongside the live narration.
+ *
+ * Active when the episode declares `chapters`; otherwise FullLayout
+ * (the legacy 2-column variant) is used.
+ */
+function MultiModalLayout({
+  displayedFen,
+  lastMove,
+  narrationSquares,
+  narrationAnnotations,
+  narrationArrows,
+  moveCounterText,
+  liveCaption,
+  evalPct,
+  evalLabel,
+  activeChapter,
+  activeChapterIndex,
+  totalChapters,
+  activeKeyIdeas,
+  activeWhatToWatch,
+  fullMoveList,
+  activePly,
+  activeFunFact,
+}: MultiModalSlotProps) {
+  return (
+    <div className="w-screen h-screen bg-surface-0 text-text-primary flex flex-col overflow-hidden">
+      {/* Chapter header bar — full width. Shows chapter number badge,
+          title, and subtitle. Right side: move counter. */}
+      <header className="h-24 px-10 flex items-center justify-between border-b border-surface-2 shrink-0">
+        <div className="flex items-baseline gap-6">
+          <div className="text-cyan-400 text-sm font-semibold uppercase tracking-widest">
+            Chapter {activeChapterIndex + 1} / {totalChapters}
+          </div>
+          <div>
+            <div className="text-3xl font-bold leading-tight">{activeChapter.title}</div>
+            {activeChapter.subtitle && (
+              <div className="text-base text-text-muted mt-0.5">{activeChapter.subtitle}</div>
+            )}
+          </div>
+        </div>
+        <div className="text-xl text-text-secondary font-mono">{moveCounterText}</div>
+      </header>
+
+      <main className="flex-1 flex min-h-0">
+        {/* Column 1: Board (~900px) */}
+        <section className="flex-1 flex flex-col items-center justify-center px-6 min-w-0">
+          <div style={{ zoom: 2.35 }}>
+            <Board
+              fen={displayedFen}
+              lastMove={lastMove}
+              highlightSquares={narrationSquares}
+              arrows={narrationArrows}
+              annotations={narrationAnnotations}
+            />
+          </div>
+          <EvalBar pct={evalPct} label={evalLabel} className="mt-4 w-[560px]" />
+        </section>
+
+        {/* Column 2: Caption + full move list (~480px) */}
+        <aside className="w-[480px] border-l border-surface-2 flex flex-col min-h-0 px-6 py-5 gap-4 shrink-0">
+          <CaptionCard text={liveCaption} />
+          <FullMoveListPanel moves={fullMoveList} activePly={activePly} />
+        </aside>
+
+        {/* Column 3: Key ideas + what to watch + fun fact (~480px) */}
+        <aside className="w-[480px] border-l border-surface-2 flex flex-col min-h-0 px-6 py-5 gap-4 shrink-0">
+          {activeKeyIdeas && <KeyIdeasPanel ideas={activeKeyIdeas} />}
+          {activeWhatToWatch && <WhatToWatchPanel text={activeWhatToWatch} />}
+          {activeFunFact && <FunFactStrip fact={activeFunFact} />}
+        </aside>
+      </main>
+    </div>
+  );
 }
 
 /**
@@ -368,6 +570,113 @@ function CommentaryPanel({ text, large, extraLarge }: { text: string; large?: bo
   return (
     <div className={`text-text-primary ${size} font-medium`}>
       {text || <span className="text-text-muted italic">Commentary will appear here...</span>}
+    </div>
+  );
+}
+
+/**
+ * Multi-modal caption card — used in the new MultiModalLayout. Same
+ * data as CommentaryPanel but rendered with a panel chrome (ring,
+ * header label) so it sits visually distinct from the other sidebar
+ * panels.
+ */
+function CaptionCard({ text }: { text: string }) {
+  return (
+    <div className="rounded-lg ring-1 ring-surface-2 bg-surface-1/40 px-5 py-4">
+      <div className="text-xs uppercase text-text-muted mb-2 tracking-widest">Narration</div>
+      <div className="text-lg leading-snug font-medium text-text-primary">
+        {text || <span className="text-text-muted italic">…</span>}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full move list with the current move highlighted. Used in the new
+ * multi-modal layout. Renders all parsed PGN plies, two columns
+ * (white + black) per turn, with the active ply boxed in cyan.
+ */
+function FullMoveListPanel({
+  moves,
+  activePly,
+}: {
+  moves: { num: number; white?: string; black?: string; whitePly?: number; blackPly?: number }[];
+  activePly: number;
+}) {
+  return (
+    <div className="flex-1 min-h-0 overflow-hidden">
+      <div className="text-xs uppercase text-text-muted mb-2 tracking-widest">Line on board</div>
+      <div className="grid grid-cols-[2.5rem_1fr_1fr] gap-x-3 gap-y-1 text-base font-mono">
+        {moves.map((m) => (
+          <>
+            <div key={`n${m.num}`} className="text-text-muted text-right pr-1">{m.num}.</div>
+            <div
+              key={`w${m.num}`}
+              className={`px-2 py-0.5 rounded ${
+                m.whitePly === activePly ? 'bg-cyan-500/30 text-cyan-200 font-semibold' : 'text-text-primary'
+              }`}
+            >
+              {m.white ?? '…'}
+            </div>
+            <div
+              key={`b${m.num}`}
+              className={`px-2 py-0.5 rounded ${
+                m.blackPly === activePly ? 'bg-cyan-500/30 text-cyan-200 font-semibold' : 'text-text-primary'
+              }`}
+            >
+              {m.black ?? ''}
+            </div>
+          </>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Key ideas panel — bullet list scoped to the active chapter. Numbered
+ * (1, 2, 3...) with cyan accent matching the chapter badge.
+ */
+function KeyIdeasPanel({ ideas }: { ideas: string[] }) {
+  return (
+    <div className="rounded-lg ring-1 ring-surface-2 bg-surface-1/40 px-5 py-4">
+      <div className="text-xs uppercase text-text-muted mb-3 tracking-widest">Key ideas</div>
+      <ul className="space-y-3 text-base text-text-primary leading-snug">
+        {ideas.map((idea, i) => (
+          <li key={i} className="flex gap-3">
+            <span className="text-cyan-400 font-bold shrink-0 w-5">{i + 1}.</span>
+            <span>{idea}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * "What to watch" panel — strategic guidance for the active chapter.
+ * One short paragraph.
+ */
+function WhatToWatchPanel({ text }: { text: string }) {
+  return (
+    <div className="rounded-lg ring-1 ring-surface-2 bg-surface-1/40 px-5 py-4">
+      <div className="text-xs uppercase text-text-muted mb-2 tracking-widest">What to watch</div>
+      <div className="text-base text-text-secondary leading-snug">{text}</div>
+    </div>
+  );
+}
+
+/**
+ * Rotating fun-fact strip. Shows one fact at a time; the active fact
+ * is picked by BroadcastLayout's rotator based on current ply.
+ */
+function FunFactStrip({ fact }: { fact: FunFact }) {
+  return (
+    <div className="rounded-lg ring-1 ring-amber-700/40 bg-amber-900/10 px-5 py-3">
+      <div className="text-xs uppercase text-amber-400 mb-1 tracking-widest">
+        {fact.label ?? 'Fun fact'}
+      </div>
+      <div className="text-sm text-text-secondary leading-snug italic">{fact.text}</div>
     </div>
   );
 }

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -413,6 +413,10 @@ export function BroadcastView() {
         narrationAnnotations={effectiveAnnotations}
         narrationArrows={narrationArrows}
         pgnMoves={pgnMoves}
+        chapters={episode?.chapters}
+        keyIdeas={episode?.keyIdeas}
+        whatToWatch={episode?.whatToWatch}
+        funFacts={episode?.funFacts}
       />
       {/* Whiteboard overlay — full-frame scene that takes over the
           board area when an authored scene matches the current

--- a/src/episodes/london_system_lesson/index.ts
+++ b/src/episodes/london_system_lesson/index.ts
@@ -1,8 +1,135 @@
-import type { Episode } from '../types';
+import type { Episode, EpisodeChapter, KeyIdeasBlock, WhatToWatchBlock, FunFact } from '../types';
 import { LONDON_SYSTEM_LESSON_PGN } from './pgn';
 import { LONDON_SYSTEM_LESSON_COMMENTATOR } from './commentator';
 import { LONDON_VARIATIONS } from './variations';
 import { LONDON_SYSTEM_LESSON_EXPORT } from './exports';
+
+// Multi-modal authoring for the London System.
+// Main PGN: 1.d4 d5 2.Nf3 Nf6 3.Bf4 e6 4.e3 Bd6 5.Bg3 O-O 6.Bd3 c5
+//           7.c3 Nc6 8.Nbd2 b6 9.O-O Bb7 10.Bxd6 Qxd6 11.Ne5 Rfd8
+// 22 plies total. Chapters segment the lesson into 5 narrative beats.
+
+const LONDON_CHAPTERS: EpisodeChapter[] = [
+  {
+    ply: 0,
+    title: 'The London Skeleton',
+    subtitle: 'd4 + Nf3 + Bf4 — the system that needs no theory',
+  },
+  {
+    ply: 5, // White plays 3.Bf4
+    title: 'Bishop Out First',
+    subtitle: "Solving the QGD bad-bishop problem before it can exist",
+  },
+  {
+    ply: 11, // White plays 6.Bd3 (after both develop)
+    title: 'The Pyramid Comes Together',
+    subtitle: 'c3 + d4 + e3 — slightly cramped, very solid',
+  },
+  {
+    ply: 17, // White's Nbd2 + O-O coming
+    title: 'Trade or Pressure?',
+    subtitle: "The Bxd6 trade question — keep the bishop or simplify?",
+  },
+  {
+    ply: 21, // Move 11 — Ne5 reaches the outpost
+    title: 'Ne5 — The London Outpost',
+    subtitle: 'Where every London plan converges',
+  },
+];
+
+const LONDON_KEY_IDEAS: KeyIdeasBlock[] = [
+  {
+    chapterPly: 0,
+    ideas: [
+      "White plays the same setup regardless of Black's reply — minimum theory.",
+      "Bf4 puts the dark-squared bishop OUTSIDE the pawn chain (solves the QGD's bad-bishop problem).",
+      "The London is the most popular club opening of the 2020s.",
+      "Used by Carlsen, So, Caruana, and most online grinders.",
+    ],
+  },
+  {
+    chapterPly: 5,
+    ideas: [
+      "3.Bf4 commits the dark-squared bishop BEFORE the pawn chain locks in.",
+      "Black's mirror response: ...Bd6 contests the long diagonal.",
+      "Trading dark-squared bishops simplifies for both sides — neither is materially behind.",
+      "If Black plays ...Qb6 attacking b2 instead, see the Anti-London variation.",
+    ],
+  },
+  {
+    chapterPly: 11,
+    ideas: [
+      "c3 + d4 + e3 = the 'London Pyramid'. Slightly cramped, but very durable.",
+      "The d4 pawn is the foundation — losing it means losing the whole structure.",
+      "Bd3 aims at h7, often supporting Ne5 + Qh5 attacks later.",
+      "Black breaks with ...c5 to challenge d4 (or ...e5 in some variations).",
+    ],
+  },
+  {
+    chapterPly: 17,
+    ideas: [
+      "Bxd6 trades a strong bishop for a strong piece — usually equal.",
+      "Keeping bishops means risking ...Nh5 chasing Bf4 to a worse square.",
+      "After Bxd6 Qxd6, Black's queen sits beautifully — but White gets Ne5 plans.",
+      "The trade simplifies White's plan: Ne5 outpost + slow kingside.",
+    ],
+  },
+  {
+    chapterPly: 21,
+    ideas: [
+      "Ne5 is the London's signature middlegame outpost — controlled by f4 + d4 pawns.",
+      "From e5, the knight pressures f7, c6, d7 — and supports f4-f5 attack.",
+      "Black often answers with ...Nd7 to challenge or ...Nxe5 to trade.",
+      "If Black trades, White's central pawn structure dominates the endgame.",
+    ],
+  },
+];
+
+const LONDON_WHAT_TO_WATCH: WhatToWatchBlock[] = [
+  {
+    chapterPly: 0,
+    text: "Watch how White's first three moves never change. The Bf4 commitment is what makes this 'the London' — the f4 square pins the system together.",
+  },
+  {
+    chapterPly: 5,
+    text: "Watch whether Black mirrors with ...Bd6 (most common) or sidesteps the bishop trade. Bishop swaps here are EQUAL — neither side gets a material edge.",
+  },
+  {
+    chapterPly: 11,
+    text: "Watch the d4 square. If Black can force ...cxd4 cxd4 ...e5, the pyramid collapses. If White holds d4, the slow squeeze begins.",
+  },
+  {
+    chapterPly: 17,
+    text: "Watch the bishop-pair count. After Bxd6 Qxd6, both sides have one bishop and the structure is symmetric — the position becomes purely strategic.",
+  },
+  {
+    chapterPly: 21,
+    text: "Watch the Ne5 square's defenders and attackers. Whoever wins the e5 fight wins the middlegame; the rest of the position rotates around it.",
+  },
+];
+
+const LONDON_FUN_FACTS: FunFact[] = [
+  {
+    label: 'History',
+    text: "The London System gets its name from the 1922 London tournament where it was played by several top masters.",
+  },
+  {
+    label: 'Modern usage',
+    text: "Magnus Carlsen plays the London regularly in online blitz — his game vs Nakamura at the 2022 Norway Chess featured this exact 11-move setup.",
+  },
+  {
+    label: 'Theory',
+    text: "Unlike the Queen's Gambit, the London avoids the entire QGD/Slav theory complex — it's the same setup against any Black response.",
+  },
+  {
+    label: 'Quote',
+    text: "Eric Rosen on the London: 'It's not the best opening, but it's the most STABLE — you'll always know what to do.'",
+  },
+  {
+    label: 'Patterns',
+    text: "The 'London Pyramid' (c3+d4+e3) is one of the most durable pawn formations in chess — it can survive most middlegame breaks.",
+  },
+];
 
 export const LONDON_SYSTEM_LESSON_EPISODE: Episode = {
   id: 'london_system_lesson',
@@ -13,6 +140,10 @@ export const LONDON_SYSTEM_LESSON_EPISODE: Episode = {
   source: 'agent_generated',
   pgn: LONDON_SYSTEM_LESSON_PGN,
   commentator: LONDON_SYSTEM_LESSON_COMMENTATOR,
+  chapters: LONDON_CHAPTERS,
+  keyIdeas: LONDON_KEY_IDEAS,
+  whatToWatch: LONDON_WHAT_TO_WATCH,
+  funFacts: LONDON_FUN_FACTS,
   exports: LONDON_SYSTEM_LESSON_EXPORT,
 };
 

--- a/src/episodes/types.ts
+++ b/src/episodes/types.ts
@@ -99,6 +99,35 @@ export interface Episode {
    * what the standard capture produces.
    */
   whiteboardScenes?: WhiteboardScene[];
+  /**
+   * Chapter markers — divide the lesson into named segments. Drives
+   * the chapter header in the multi-modal broadcast layout and the
+   * scoping of `keyIdeas` / `whatToWatch` / `funFacts` panels.
+   *
+   * Optional. Episodes without chapters render in the legacy
+   * single-panel layout (no chapter bar, no key-ideas panel).
+   */
+  chapters?: EpisodeChapter[];
+  /**
+   * Persistent "key ideas" panel content. Each `KeyIdeasBlock` is
+   * scoped to a chapter (by `chapterPly`) and shows 3-5 bullet points
+   * while that chapter is active.
+   *
+   * No bullets shown for chapters without a matching block.
+   */
+  keyIdeas?: KeyIdeasBlock[];
+  /**
+   * Persistent "what to watch" panel — one short paragraph per
+   * chapter giving the viewer strategic guidance for what to focus
+   * on during that segment.
+   */
+  whatToWatch?: WhatToWatchBlock[];
+  /**
+   * Optional rotating "fun fact" strip — historical asides, theory
+   * trivia, or quotes. Rotated through during the lesson; no chapter
+   * scoping (facts can show whenever).
+   */
+  funFacts?: FunFact[];
   /** Export configuration. Present once the episode is planned for export. */
   exports?: EpisodeExportConfig;
   /** Published references (e.g. YouTube URLs). Workspace-tracked. */
@@ -236,6 +265,65 @@ export interface WhiteboardArrowDiagramScene extends WhiteboardSceneBase {
   arrows: Array<{ from: string; to: string; label?: string; color?: string }>;
   /** Optional caption below the diagram. */
   caption?: string;
+}
+
+/**
+ * A chapter marker — divides the lesson into named segments. The
+ * chapter is "active" from `ply` until the next chapter's `ply`
+ * (or end of episode).
+ *
+ * The chapter header appears at the top of the multi-modal layout
+ * showing the chapter number + title + subtitle. Chapter changes
+ * trigger updates to the keyIdeas / whatToWatch panels.
+ */
+export interface EpisodeChapter {
+  /** 1-indexed ply this chapter starts at. 0 = before any move (intro). */
+  ply: number;
+  /** Short chapter title, e.g. "The Italian Setup". */
+  title: string;
+  /** One-line subtitle / description, e.g. "Both sides develop classically". */
+  subtitle?: string;
+}
+
+/**
+ * A block of key-idea bullets scoped to a specific chapter. Renders
+ * in the "Key ideas" sidebar while the matched chapter is active.
+ */
+export interface KeyIdeasBlock {
+  /** Must match an EpisodeChapter.ply to scope this block to that chapter. */
+  chapterPly: number;
+  /** 3-5 short bullets, each ~10-15 words. */
+  ideas: string[];
+}
+
+/**
+ * Strategic guidance shown in the "What to watch" panel during a
+ * chapter. One short paragraph; the viewer focus prompt for that
+ * segment.
+ */
+export interface WhatToWatchBlock {
+  /** Must match an EpisodeChapter.ply. */
+  chapterPly: number;
+  /** One paragraph (3-5 sentences) of strategic guidance. */
+  text: string;
+}
+
+/**
+ * A rotating fun-fact — historical asides, theory trivia, or quotes.
+ * Optionally scoped to a ply range; unscoped facts show anywhere.
+ *
+ * Rotated through during the lesson; one fact visible at a time in
+ * the funFacts strip (or panel) for ~20s before rotating to the next.
+ */
+export interface FunFact {
+  /** Short label / category, e.g. "Historical", "Theory", "Quote". */
+  label?: string;
+  /** Fact text — 1-2 sentences, ~25 words max for readability. */
+  text: string;
+  /** Earliest ply this fact can show. Default 0 (always available). */
+  minPly?: number;
+  /** Latest ply this fact can show. Default Infinity (always available). */
+  maxPly?: number;
 }
 
 /** Provenance of the PGN that backs the Episode. */


### PR DESCRIPTION
## Summary

A new 3-column landscape layout for episodes that author chapter content. Inspired by the Codex London frame the user endorsed: \"we can use the space we have in our video format to show information that is not just the tts narration.\"

| Column | Content |
|---|---|
| Col 1 (~900px) | Board + eval bar |
| Col 2 (~480px) | Caption card + FULL move list (current ply highlighted) |
| Col 3 (~480px) | Key ideas + what to watch + rotating fun fact |

Plus a chapter header bar at top: \`CHAPTER N / total · title · subtitle · move counter\`.

## Backwards compatible

Episodes WITHOUT \`chapters\` render in the existing 2-column layout. **No other episode changes.** Authoring drives layout selection.

## Schema additions

[\`src/episodes/types.ts\`](src/episodes/types.ts):
- \`Episode.chapters\` — \`{ ply, title, subtitle }[]\`
- \`Episode.keyIdeas\` — \`{ chapterPly, ideas: string[] }[]\`
- \`Episode.whatToWatch\` — \`{ chapterPly, text }[]\`
- \`Episode.funFacts\` — \`{ label?, text, minPly?, maxPly? }[]\`

## London System rich content

[\`src/episodes/london_system_lesson/index.ts\`](src/episodes/london_system_lesson/index.ts):
- **5 chapters**: The London Skeleton → Bishop Out First → The Pyramid Comes Together → Trade or Pressure → Ne5 The London Outpost
- 4 key ideas per chapter (20 total bullets)
- 5 \"what to watch\" guidance paragraphs
- 5 rotating fun facts (history / modern usage / theory / quotes / patterns)

## Companion design doc

[\`docs/design-branch-playback.md\`](docs/design-branch-playback.md) — full pre-implementation spec for the next big PR (instructor board control / rollback). Schema, runtime changes, event types, visual sequence, ~750 LoC estimate.

## Test plan

- [x] Typecheck clean
- [ ] Smoke-capture \`london_system_lesson\` and verify multi-modal layout renders
- [ ] Confirm Italian Game (no chapters) still uses the legacy 2-column layout
- [ ] Visual audit: chapter transitions, key-ideas update on chapter change, fun-fact rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-modal sidebars to broadcast view with chapter markers, key learning ideas, strategic watch guidance, and rotating fun facts.
  * Enhanced episode content display with dedicated UI panels for structured educational information during lessons.

* **Documentation**
  * Added design specification for branch playback feature enabling instructor-controlled board state navigation during interactive lessons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->