### PR TITLE
fix(mp4-export): drop -tune stillimage, switch to CRF 16, bump JPEG q92

### DIFF
--- a/scripts/lib/export/browserCapture.ts
+++ b/scripts/lib/export/browserCapture.ts
@@ -15,8 +15,16 @@ import { registerPid } from './processRegistry';
 import { FrameSequenceWriter } from './frameSequenceWriter';
 
 const DEFAULT_FRAME_RATE = 30;
-const SCREENCAST_QUALITY_DEFAULT = 84;
-const SCREENCAST_QUALITY_FAST = 60;
+// JPEG quality for the CDP screencast frames. Higher = more source
+// detail for the H.264 encoder downstream. We're encoding 1080p
+// text-heavy content (board lines, captions, move list) where JPEG
+// chroma subsampling artifacts smear edges; quality 92 keeps those
+// edges crisp before the encoder ever sees them. Frame files are
+// ~20% bigger than at q84 but that's not a bottleneck.
+const SCREENCAST_QUALITY_DEFAULT = 92;
+// Fast mode (--fast flag) — lower quality for iteration speed. The
+// final upload should never use this.
+const SCREENCAST_QUALITY_FAST = 70;
 const EXPORT_READY_TIMEOUT_MS = 180_000;
 const CAPTURE_POSTROLL_MS = 500;
 

--- a/scripts/lib/export/ffmpegCompose.ts
+++ b/scripts/lib/export/ffmpegCompose.ts
@@ -34,34 +34,48 @@ export interface ComposeOptions {
 
 /**
  * Upload-grade H.264 encoder args, shared between the compose pass and
- * the dead-air re-encode. The previous CRF-20 / veryfast setup
- * produced 0.1–0.5 Mbps streams for mostly-static board content, which
- * smeared text and thin board lines once YouTube re-encoded them.
+ * the dead-air re-encode.
  *
- * Target: 1080p text-heavy content that survives one round of YouTube
- * transcode without breaking down. Both landscape (1920×1080) and
- * portrait (1080×1920) carry ~2M pixels per frame, so the same target
- * bitrate works for both.
+ * History:
+ *   v1 (PR #59): -b:v 8M -maxrate 10M -bufsize 16M with -tune stillimage
+ *                Produced ~500 kb/s in practice — the `stillimage` tune
+ *                tells x264 the source is screenshot-grade and triggers
+ *                hyper-aggressive psy-rd / aq settings, causing ABR
+ *                mode to massively undershoot the 8 Mbps target.
  *
- *   -b:v 8M -maxrate 10M -bufsize 16M  8 Mbps target with headroom
- *   -preset slow                       better compression at same bitrate
- *                                      (trades encode time for quality)
- *   -tune stillimage                   x264 mode optimized for static
- *                                      text/diagram content
- *   -profile:v high -level 4.1         standard 1080p H.264 profile
- *   -pix_fmt yuv420p                   QuickTime / browser compat
- *   -movflags +faststart               metadata at file head for streaming
+ *   v2 (this):   -crf 16 with VBV ceiling, no tune.
+ *                CRF mode targets visual quality directly. CRF 16 is
+ *                "visually transparent" — x264 produces whatever
+ *                bitrate is needed to maintain that fidelity. For
+ *                1080p text-heavy chess content this typically lands
+ *                in the 3-6 Mbps range — high enough to survive
+ *                YouTube re-encoding without smearing.
+ *
+ * Settings:
+ *   -crf 16              visually transparent quality target
+ *   -maxrate 12M         VBV ceiling — won't peak above this
+ *   -bufsize 24M         2x maxrate buffer for steady decoding
+ *   -preset slow         better compression efficiency at the
+ *                        same quality (trades encode time)
+ *   -profile:v high -level 4.1   standard 1080p H.264 profile
+ *   -pix_fmt yuv420p     QuickTime / browser compat
+ *   -movflags +faststart metadata at file head for streaming
+ *
+ * No -tune. The board has enough motion (caption updates, eval bar
+ * shifts, recent-moves panel changes, fun-fact rotation) that
+ * `stillimage` is the wrong assumption. `animation` would also work
+ * (sparse-color, sharp edges) but the default psy settings produce
+ * crisp text reliably.
  */
 const VIDEO_ENCODE_ARGS = [
   '-c:v', 'libx264',
   '-preset', 'slow',
-  '-tune', 'stillimage',
   '-profile:v', 'high',
   '-level', '4.1',
   '-pix_fmt', 'yuv420p',
-  '-b:v', '8M',
-  '-maxrate', '10M',
-  '-bufsize', '16M',
+  '-crf', '16',
+  '-maxrate', '12M',
+  '-bufsize', '24M',
   '-movflags', '+faststart',
 ];
 


### PR DESCRIPTION
London reshoot landed at 502 kb/s despite -b:v 8M. `-tune stillimage` was sabotaging ABR mode (sees screenshot-grade source → crushes bitrate). Replacing with CRF 16 + VBV ceiling, plus q84→q92 JPEGs for more upstream detail.