### PR TITLE
chore: trace-mcp project config

### DIFF
--- a/.trace-mcp/.gitignore
+++ b/.trace-mcp/.gitignore
@@ -1,0 +1,3 @@
+# Trace MCP cache (regenerated)
+cache/
+reports/

--- a/.trace-mcp/config.json
+++ b/.trace-mcp/config.json
@@ -1,0 +1,34 @@
+{
+  "version": "1.0.0",
+  "producer": {
+    "path": "src/llm",
+    "language": "typescript",
+    "include": [
+      "**/*.ts"
+    ],
+    "exclude": [
+      "**/*.test.ts",
+      "**/node_modules/**",
+      "**/dist/**"
+    ]
+  },
+  "consumer": {
+    "path": "src",
+    "language": "typescript",
+    "include": [
+      "**/*.ts",
+      "**/*.tsx"
+    ],
+    "exclude": [
+      "**/*.test.ts",
+      "**/node_modules/**",
+      "**/dist/**"
+    ]
+  },
+  "options": {
+    "strict": false,
+    "direction": "producer_to_consumer",
+    "debounceMs": 300,
+    "autoWatch": true
+  }
+}


### PR DESCRIPTION
Initializes schema-validation tooling. 7 chess_move tool schemas extracted, 0 mismatches.