### PR TITLE
feat(engine): board branch playback (instructor "what if" interludes)

### DIFF
--- a/src/commentary/commentaryQueue.ts
+++ b/src/commentary/commentaryQueue.ts
@@ -1,6 +1,7 @@
 import type { EvalResult } from '../chess/stockfish';
 import type { CommentaryContext } from '../llm/prompts';
 import { buildCommentaryPrompt, VERBOSITY_TOKEN_MAP } from '../llm/prompts';
+import type { BoardBranch } from '../episodes/types';
 import type { LLMClient } from '../llm/client';
 import type { CommentatorConfig } from '../engine/types';
 import { buildBatchCommentaryPrompt } from './batchPrompt';
@@ -516,6 +517,117 @@ Provide a post-game recap: summarize the key moments, turning points, and decisi
       const message = err instanceof Error ? err.message : String(err);
       console.warn('[Commentary] Recap failed:', message);
       this.completeEntry(entryIndex, buildRecapFallback(whiteModel, blackModel, result, totalMoves, ttsMode));
+    }
+  }
+
+  /**
+   * Generate a single narration block covering an entire board branch.
+   *
+   * The branch is an "instructor pause" — the lesson rewinds the board,
+   * plays an alternative line, then restores. This call produces ONE
+   * spoken paragraph that opens the branch and previews what the
+   * viewer is about to see, while the board sits on the starting FEN.
+   * Branch moves then fire on the board with delays; we do NOT generate
+   * per-branch-move commentary (that's a v2 enhancement).
+   *
+   * The runtime awaits this call before the first branch move fires.
+   */
+  async generateBranch(branch: BoardBranch, startingFen: string): Promise<void> {
+    if (this.destroyed) return;
+    const model = this.config.getCommentatorModel();
+    if (!model.id) return;
+    console.log('[Commentary] generateBranch %s: starting with model=%s', branch.id, model.id);
+
+    // Block processNext for the duration so the branch entry is the
+    // singular focus, just like generateIntro does.
+    this.active = [];
+
+    const entry: CommentaryEntry = {
+      id: genId(),
+      moves: [],
+      text: '',
+      streaming: true,
+      timestamp: Date.now(),
+      maxMoveIndex: -1,
+      isFiller: true,
+    };
+    this.entries = [...this.entries, entry];
+    const entryIndex = this.entries.length - 1;
+    this.emit();
+    let abortCtrl: AbortController | null = null;
+
+    const ttsMode = this.config.getTtsMode?.() ?? false;
+    const titleLine = branch.title ? `Branch title: ${branch.title}.\n` : '';
+    const branchPrompt = `You are narrating a teaching BRANCH — a hypothetical alternative line the lesson is about to play on the board. The viewer will SEE the next ${branch.branchMoves.length} moves play out, then the board snaps back to the main line.
+
+${titleLine}Branch starting position FEN: ${startingFen}
+Branch moves (will play in this order): ${branch.branchMoves.join(' ')}
+
+Educational point of the branch: ${branch.narrationCue}
+
+Write 2-3 spoken sentences that OPEN the branch — frame what the viewer is about to see, the question this branch answers, and what to watch for. ${ttsMode ? 'Spoken naturally, no markdown.' : 'Use rich markdown.'}
+
+Do NOT walk through every branch move individually — the board does that visually. Stay at the strategic / "why we're showing this" level. Do NOT reference "the video", "the viewer", or "the audience". Do NOT add a closing transition; the runtime will return to the main line on its own.`;
+
+    try {
+      const client = this.config.getClient();
+      abortCtrl = new AbortController();
+      this.activeGenerationAbort = abortCtrl;
+
+      const messages: import('../llm/prompts').ChatMessage[] = [
+        {
+          role: 'system',
+          content:
+            this.config.systemPromptOverride ??
+            `You are an expert chess instructor narrating a teaching branch — a hypothetical alternative move sequence the lesson is briefly demonstrating on the board.${ttsMode ? ' Spoken natural language only, no markdown.' : ''}`,
+        },
+        { role: 'user', content: branchPrompt },
+      ];
+
+      const result = await runResilientTextGeneration({
+        client,
+        model: model.id,
+        messages,
+        temperature: 0.8,
+        responseOptions: {
+          promptLevel: 'p0',
+          maxTokens: Math.max(model.maxTokens ?? 600, 600),
+          reasoningEffort: model.reasoningEffort,
+        },
+        abortSignal: abortCtrl.signal,
+        onText: (text) => this.updateEntryText(entryIndex, text),
+        stallTimeoutMs: 30000,
+        hardTimeoutMs: 90000,
+        maxAttempts: 2,
+      });
+      if (this.activeGenerationAbort === abortCtrl) {
+        this.activeGenerationAbort = null;
+      }
+      this.active = null;
+      this.completeEntry(
+        entryIndex,
+        result.text || (branch.title ? `Branch: ${branch.title}.` : 'Branch interlude.'),
+        true,
+      );
+    } catch (err) {
+      if (abortCtrl?.signal.aborted) {
+        if (this.activeGenerationAbort === abortCtrl) {
+          this.activeGenerationAbort = null;
+        }
+        this.active = null;
+        return;
+      }
+      if (this.activeGenerationAbort === abortCtrl) {
+        this.activeGenerationAbort = null;
+      }
+      this.active = null;
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn('[Commentary] Branch %s failed: %s', branch.id, message);
+      this.completeEntry(
+        entryIndex,
+        branch.title ? `Branch: ${branch.title}.` : 'Branch interlude.',
+        true,
+      );
     }
   }
 

--- a/src/components/BroadcastLayout.tsx
+++ b/src/components/BroadcastLayout.tsx
@@ -157,9 +157,31 @@ export function BroadcastLayout({
   // displayed FEN and for the recent-moves panel (empty during intro).
   const narratedInfo = narratedMoveInfo(gameState, narrationMoveIndex, pgnMoves);
   const startingFen = startingFenFor(gameState);
-  const displayedFen = narratedInfo?.fen ?? startingFen ?? gameState.fen;
-  const displayedLastMove =
-    narratedInfo && narratedInfo.from && narratedInfo.to
+
+  // Branch playback override. When the runtime is mid-branch, the
+  // displayed board switches to the branch's current FEN. The last
+  // move highlight follows the most recent BranchMoveApplied event
+  // (parsed from the eventLog tail). The banner is shown by the
+  // multi-modal layout when activeBranch is truthy.
+  const activeBranch = gameState.activeBranch ?? null;
+  const lastBranchMove = useMemo<{ from: string; to: string } | null>(() => {
+    if (!activeBranch) return null;
+    for (let i = gameState.eventLog.length - 1; i >= 0; i--) {
+      const evt = gameState.eventLog[i];
+      if (evt.type === 'BranchMoveApplied' && evt.payload.branchId === activeBranch.branchId) {
+        return { from: evt.payload.from, to: evt.payload.to };
+      }
+      if (evt.type === 'BranchStarted' && evt.payload.branchId === activeBranch.branchId) break;
+    }
+    return null;
+  }, [activeBranch, gameState.eventLog]);
+
+  const displayedFen = activeBranch
+    ? activeBranch.currentFen
+    : narratedInfo?.fen ?? startingFen ?? gameState.fen;
+  const displayedLastMove = activeBranch
+    ? lastBranchMove ?? undefined
+    : narratedInfo && narratedInfo.from && narratedInfo.to
       ? { from: narratedInfo.from, to: narratedInfo.to }
       : narratedInfo
         ? lastMove
@@ -307,6 +329,7 @@ export function BroadcastLayout({
       fullMoveList={fullMoveList}
       activePly={currentPly}
       activeFunFact={activeFunFact}
+      activeBranch={activeBranch}
     />;
   }
   return <FullLayout
@@ -322,8 +345,11 @@ export function BroadcastLayout({
     recentMoves={recentMoves}
     evalPct={evalPct}
     evalLabel={evalLabel}
+    activeBranch={activeBranch}
   />;
 }
+
+type ActiveBranchInfo = NonNullable<GameState['activeBranch']>;
 
 interface LayoutSlotProps {
   displayedFen: string;
@@ -338,6 +364,8 @@ interface LayoutSlotProps {
   recentMoves: { turn: number; white?: string; black?: string }[];
   evalPct: number;
   evalLabel: string;
+  /** Non-null when a branch is mid-playback. Drives the branch banner overlay. */
+  activeBranch?: ActiveBranchInfo | null;
 }
 
 interface MultiModalSlotProps {
@@ -358,6 +386,7 @@ interface MultiModalSlotProps {
   fullMoveList: { num: number; white?: string; black?: string; whitePly?: number; blackPly?: number }[];
   activePly: number;
   activeFunFact: FunFact | null;
+  activeBranch?: ActiveBranchInfo | null;
 }
 
 /**
@@ -392,30 +421,57 @@ function MultiModalLayout({
   fullMoveList,
   activePly,
   activeFunFact,
+  activeBranch,
 }: MultiModalSlotProps) {
   return (
     <div className="w-screen h-screen bg-surface-0 text-text-primary flex flex-col overflow-hidden">
       {/* Chapter header bar — full width. Shows chapter number badge,
-          title, and subtitle. Right side: move counter. */}
-      <header className="h-24 px-10 flex items-center justify-between border-b border-surface-2 shrink-0">
-        <div className="flex items-baseline gap-6">
-          <div className="text-cyan-400 text-sm font-semibold uppercase tracking-widest">
-            Chapter {activeChapterIndex + 1} / {totalChapters}
+          title, and subtitle. Right side: move counter. While a branch
+          is mid-playback, the chapter row is overlaid with a BRANCH
+          banner so the viewer instantly knows the board is showing a
+          hypothetical line, not the main lesson. */}
+      {activeBranch ? (
+        <header className="h-24 px-10 flex items-center justify-between border-b-2 border-amber-500/70 bg-amber-900/20 shrink-0">
+          <div className="flex items-baseline gap-6">
+            <div className="text-amber-400 text-sm font-bold uppercase tracking-widest">
+              Branch · Hypothetical Line
+            </div>
+            <div>
+              <div className="text-3xl font-bold leading-tight text-amber-100">
+                {activeBranch.title || 'Alternative line'}
+              </div>
+              <div className="text-base text-amber-300/80 mt-0.5">
+                What if we tried this instead? Board returns to the main line after.
+              </div>
+            </div>
           </div>
-          <div>
-            <div className="text-3xl font-bold leading-tight">{activeChapter.title}</div>
-            {activeChapter.subtitle && (
-              <div className="text-base text-text-muted mt-0.5">{activeChapter.subtitle}</div>
-            )}
+          <div className="text-xl text-amber-200 font-mono">{moveCounterText}</div>
+        </header>
+      ) : (
+        <header className="h-24 px-10 flex items-center justify-between border-b border-surface-2 shrink-0">
+          <div className="flex items-baseline gap-6">
+            <div className="text-cyan-400 text-sm font-semibold uppercase tracking-widest">
+              Chapter {activeChapterIndex + 1} / {totalChapters}
+            </div>
+            <div>
+              <div className="text-3xl font-bold leading-tight">{activeChapter.title}</div>
+              {activeChapter.subtitle && (
+                <div className="text-base text-text-muted mt-0.5">{activeChapter.subtitle}</div>
+              )}
+            </div>
           </div>
-        </div>
-        <div className="text-xl text-text-secondary font-mono">{moveCounterText}</div>
-      </header>
+          <div className="text-xl text-text-secondary font-mono">{moveCounterText}</div>
+        </header>
+      )}
 
       <main className="flex-1 flex min-h-0">
-        {/* Column 1: Board (~900px) */}
+        {/* Column 1: Board (~900px). Branch-mode adds an amber ring +
+            slight inset to distinguish the hypothetical playback. */}
         <section className="flex-1 flex flex-col items-center justify-center px-6 min-w-0">
-          <div style={{ zoom: 2.35 }}>
+          <div
+            style={{ zoom: 2.35 }}
+            className={activeBranch ? 'ring-4 ring-amber-500/60 rounded-lg' : ''}
+          >
             <Board
               fen={displayedFen}
               lastMove={lastMove}
@@ -466,25 +522,43 @@ function FullLayout({
   recentMoves,
   evalPct,
   evalLabel,
+  activeBranch,
 }: LayoutSlotProps) {
   return (
     <div className="w-screen h-screen bg-surface-0 text-text-primary flex flex-col overflow-hidden">
-      {/* Title bar */}
-      <header className="h-20 px-10 flex items-center justify-between border-b border-surface-2 shrink-0">
-        <div>
-          <div className="text-3xl font-bold leading-tight">{title}</div>
-          {subtitle && <div className="text-sm text-text-muted mt-0.5">{subtitle}</div>}
-        </div>
-        <div className="text-xl text-text-secondary font-mono">{moveCounterText}</div>
-      </header>
+      {/* Title bar (or branch banner when mid-branch). */}
+      {activeBranch ? (
+        <header className="h-20 px-10 flex items-center justify-between border-b-2 border-amber-500/70 bg-amber-900/20 shrink-0">
+          <div>
+            <div className="text-amber-400 text-xs font-bold uppercase tracking-widest">
+              Branch · Hypothetical Line
+            </div>
+            <div className="text-2xl font-bold leading-tight text-amber-100">
+              {activeBranch.title || 'Alternative line'}
+            </div>
+          </div>
+          <div className="text-xl text-amber-200 font-mono">{moveCounterText}</div>
+        </header>
+      ) : (
+        <header className="h-20 px-10 flex items-center justify-between border-b border-surface-2 shrink-0">
+          <div>
+            <div className="text-3xl font-bold leading-tight">{title}</div>
+            {subtitle && <div className="text-sm text-text-muted mt-0.5">{subtitle}</div>}
+          </div>
+          <div className="text-xl text-text-secondary font-mono">{moveCounterText}</div>
+        </header>
+      )}
 
       {/* Main split: board left, commentary + moves right */}
       <main className="flex-1 flex min-h-0">
         {/* Board column - fills available height. CSS zoom scales the
             384 px board up to ~922 px while keeping pixel-perfect
-            chess geometry. */}
+            chess geometry. Branch-mode adds an amber ring. */}
         <section className="flex-1 flex flex-col items-center justify-center px-10 min-w-0">
-          <div style={{ zoom: 2.4 }}>
+          <div
+            style={{ zoom: 2.4 }}
+            className={activeBranch ? 'ring-4 ring-amber-500/60 rounded-lg' : ''}
+          >
             <Board
               fen={displayedFen}
               lastMove={lastMove}

--- a/src/components/BroadcastView.tsx
+++ b/src/components/BroadcastView.tsx
@@ -214,6 +214,13 @@ export function BroadcastView() {
           });
         });
 
+        // Resolve board branches from the active episode (or the
+        // variation if we're capturing one).
+        const branchEpisode = config.episodeId ? getEpisode(config.episodeId) : undefined;
+        const boardBranches = config.variationId
+          ? undefined // variations are themselves alternative lines — no nested branches
+          : branchEpisode?.boardBranches;
+
         startReplay(pgnText, {
           historicalContext,
           lessonContext,
@@ -225,6 +232,7 @@ export function BroadcastView() {
           moveDelayMs: 2000,
           paceWithNarration: true,
           startFromPly: shortRange?.startPly ?? 0,
+          boardBranches,
         });
       },
       reset: () => {

--- a/src/engine/events.ts
+++ b/src/engine/events.ts
@@ -186,6 +186,60 @@ export interface ErrorOccurredEvent extends BaseEvent {
   };
 }
 
+// ───────────────────────────────────────────────────────────────
+// Branch playback events (Track A instructor board control).
+//
+// A "branch" is a hypothetical line the lesson plays on the actual
+// board, then returns from. Conceptually: pause main → rewind/jump
+// to a starting FEN → play branchMoves[] → restore main position.
+// The reducer tracks branch state separately from the main move
+// history so consumers can render the branch overlay without
+// polluting the canonical move list.
+// ───────────────────────────────────────────────────────────────
+
+export interface BranchStartedEvent extends BaseEvent {
+  type: 'BranchStarted';
+  payload: {
+    /** Stable id for this branch (matches BoardBranch.id if authored). */
+    branchId: string;
+    /** Episode ply the main line was on when the branch fired. */
+    fromMainPly: number;
+    /** FEN we'll rewind to before playing branchMoves[]. */
+    startingFen: string;
+    /** Display title for the banner overlay. Empty string = no banner. */
+    title: string;
+  };
+}
+
+export interface BranchMoveAppliedEvent extends BaseEvent {
+  type: 'BranchMoveApplied';
+  payload: {
+    /** Same branch id as the wrapping BranchStarted. */
+    branchId: string;
+    /** 1-indexed position within this branch's branchMoves[]. */
+    branchPly: number;
+    color: PieceColor;
+    san: string;
+    from: string;
+    to: string;
+    fen: string;
+    isCheck: boolean;
+    isCheckmate: boolean;
+    isCapture: boolean;
+  };
+}
+
+export interface BranchEndedEvent extends BaseEvent {
+  type: 'BranchEnded';
+  payload: {
+    branchId: string;
+    /** FEN of the main line we restored to. */
+    resumeFen: string;
+    /** Episode ply the main line resumes from. Usually == fromMainPly. */
+    resumeMainPly: number;
+  };
+}
+
 export type GameEvent =
   | GameCreatedEvent
   | GameStartedEvent
@@ -198,6 +252,9 @@ export type GameEvent =
   | IllegalMoveAttemptedEvent
   | GameEndedEvent
   | GameAbortedEvent
-  | ErrorOccurredEvent;
+  | ErrorOccurredEvent
+  | BranchStartedEvent
+  | BranchMoveAppliedEvent
+  | BranchEndedEvent;
 
 export type GameEventType = GameEvent['type'];

--- a/src/engine/reducer.ts
+++ b/src/engine/reducer.ts
@@ -134,6 +134,58 @@ export function gameReducer(state: GameState, event: GameEvent): GameState {
       }
       return withEvent;
 
+    // ───────────────────────────────────────────────────────
+    // Branch playback events. Branch state lives in
+    // state.activeBranch — NOT in moveHistory. Consumers
+    // (BroadcastLayout) render the branch position when
+    // activeBranch is non-null; otherwise they show the main
+    // line's `fen` field as usual.
+    // ───────────────────────────────────────────────────────
+
+    case 'BranchStarted':
+      return {
+        ...withEvent,
+        activeBranch: {
+          branchId: event.payload.branchId,
+          title: event.payload.title,
+          startingFen: event.payload.startingFen,
+          currentFen: event.payload.startingFen,
+          moves: [],
+          resumeMainPly: event.payload.fromMainPly,
+        },
+      };
+
+    case 'BranchMoveApplied': {
+      if (!state.activeBranch) return withEvent;
+      return {
+        ...withEvent,
+        activeBranch: {
+          ...state.activeBranch,
+          currentFen: event.payload.fen,
+          moves: [
+            ...state.activeBranch.moves,
+            {
+              turnNumber: Math.ceil(event.payload.branchPly / 2),
+              color: event.payload.color,
+              move: event.payload.san,
+              thinkingTimeMs: 0,
+              attempts: 1,
+            },
+          ],
+        },
+      };
+    }
+
+    case 'BranchEnded':
+      // Restoring fen on the main state. moveHistory is unchanged
+      // (the branch was never part of the main line). The next
+      // MoveApplied for the main line continues from here.
+      return {
+        ...withEvent,
+        fen: event.payload.resumeFen,
+        activeBranch: null,
+      };
+
     default:
       return withEvent;
   }

--- a/src/engine/runtime.ts
+++ b/src/engine/runtime.ts
@@ -12,6 +12,7 @@ import type {
   ResponseToolInvocation,
   TurnContext,
 } from './types';
+import type { BoardBranch } from '../episodes/types';
 import type { GameEvent } from './events';
 import { gameReducer } from './reducer';
 import { ChessBoard } from '../chess/board';
@@ -55,6 +56,22 @@ export class GameRuntime {
   private replayMoveDelayMs = 800;
   private replayResult: import('./types').GameResult | null = null;
   private replayPaceCheck: (() => Promise<void>) | null = null;
+  /**
+   * Branches indexed by `afterPly`. When a replay move at ply N completes,
+   * we look up boardBranches[N] and execute it before continuing.
+   * Empty when the episode has no branches (default).
+   */
+  private boardBranches: Map<number, BoardBranch> = new Map();
+  /**
+   * Optional hook called when a branch is about to start. The
+   * commentary queue uses this to generate branch-specific narration
+   * BEFORE branch moves play (so the audio leads the visuals).
+   * Returns a promise that the runtime awaits before the first
+   * branch move fires.
+   */
+  private branchNarrationHook:
+    | ((branch: BoardBranch, startingFen: string) => Promise<void>)
+    | null = null;
 
   constructor(
     white: PlayerConfig,
@@ -158,6 +175,135 @@ export class GameRuntime {
    */
   setReplayPaceCheck(fn: (() => Promise<void>) | null): void {
     this.replayPaceCheck = fn;
+  }
+
+  /**
+   * Register board branches for the current replay. Branches fire AFTER
+   * the main-line move at `afterPly` completes — runtime pauses the main
+   * loop, rewinds the board to the branch's startingFen, plays each
+   * branch move, then restores the main-line position before continuing.
+   *
+   * Branches are keyed by `afterPly`; only one branch per ply is supported
+   * (later branches at the same ply overwrite earlier ones). Pass an
+   * empty array to clear.
+   */
+  setBoardBranches(branches: BoardBranch[]): void {
+    this.boardBranches = new Map(branches.map((b) => [b.afterPly, b]));
+  }
+
+  /**
+   * Set the branch-narration hook. The runtime awaits this BEFORE the
+   * first branch move fires, so the commentary queue can generate +
+   * start narrating the branch context while the board sits on the
+   * starting position. Returns a promise the runtime awaits.
+   */
+  setBranchNarrationHook(
+    fn: ((branch: BoardBranch, startingFen: string) => Promise<void>) | null,
+  ): void {
+    this.branchNarrationHook = fn;
+  }
+
+  /**
+   * Execute a branch: emit BranchStarted, rewind board to startingFen,
+   * play each branch move (validating via chess.js, awaiting the move
+   * delay between each), then emit BranchEnded and restore the main
+   * line's FEN.
+   *
+   * The chess.js board state IS mutated during the branch (loaded to
+   * startingFen, then moves applied). We save the main FEN BEFORE the
+   * branch and reload AFTER, so subsequent main-line moves continue
+   * from the right position.
+   */
+  private async executeBranch(branch: BoardBranch, mainPly: number): Promise<void> {
+    if (this.aborted) return;
+    const mainFenBeforeBranch = this.chess.fen();
+    // Resolve startingFen: rewind to fromPly (if specified < afterPly).
+    // Otherwise use the current position. fromPly is 1-indexed; index
+    // into fenHistory[N] = FEN AFTER ply N (fenHistory[0] = starting).
+    const fromPly = branch.fromPly ?? branch.afterPly;
+    const rewindIndex = Math.max(0, Math.min(this.fenHistory.length - 1, fromPly));
+    const startingFen = this.fenHistory[rewindIndex] ?? mainFenBeforeBranch;
+
+    this.emit({
+      type: 'BranchStarted',
+      payload: {
+        branchId: branch.id,
+        fromMainPly: mainPly,
+        startingFen,
+        title: branch.title ?? '',
+      },
+    });
+
+    // Let the commentary queue lead with branch narration.
+    if (this.branchNarrationHook) {
+      try {
+        await this.branchNarrationHook(branch, startingFen);
+      } catch (err) {
+        console.warn('[Branch] narration hook threw — continuing:', err);
+      }
+    }
+    if (this.aborted) return;
+
+    // Rewind the chess.js board.
+    this.chess.load(startingFen);
+
+    const delay = branch.branchMoveDelayMs ?? 1800;
+    for (let i = 0; i < branch.branchMoves.length; i++) {
+      if (this.aborted) break;
+      const san = branch.branchMoves[i];
+      const validation = this.chess.validateMove(san);
+      if (!validation.legal) {
+        console.warn(
+          `[Branch ${branch.id}] illegal move ${san} at branch ply ${i + 1} — skipping rest of branch`,
+        );
+        break;
+      }
+      const moveResult = this.chess.applyMove(validation.san!);
+      const isCheckmate = this.chess.isGameOver() && this.chess.fen().includes('#'); // best-effort
+      this.emit({
+        type: 'BranchMoveApplied',
+        payload: {
+          branchId: branch.id,
+          branchPly: i + 1,
+          color: i % 2 === 0 ? (this.fenColorAt(startingFen) === 'w' ? 'w' : 'b') : this.fenColorAt(startingFen) === 'w' ? 'b' : 'w',
+          san: validation.san!,
+          from: moveResult.from,
+          to: moveResult.to,
+          fen: this.chess.fen(),
+          isCheck: this.chess.isCheck(),
+          isCheckmate,
+          isCapture: moveResult.captured !== undefined,
+        },
+      });
+      if (i < branch.branchMoves.length - 1 && !this.aborted) {
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+
+    // Hold the final branch position briefly so the viewer can absorb
+    // the result before the snap-back. One extra delay tick.
+    if (!this.aborted) await new Promise((r) => setTimeout(r, delay));
+
+    // Restore main line.
+    const resumeMainPly = branch.returnToPly ?? mainPly;
+    const resumeFenIndex = Math.max(0, Math.min(this.fenHistory.length - 1, resumeMainPly));
+    const resumeFen = this.fenHistory[resumeMainPly === mainPly ? this.fenHistory.length - 1 : resumeFenIndex] ?? mainFenBeforeBranch;
+    this.chess.load(resumeFen);
+
+    this.emit({
+      type: 'BranchEnded',
+      payload: {
+        branchId: branch.id,
+        resumeFen,
+        resumeMainPly,
+      },
+    });
+  }
+
+  /** Return whose turn it is at `fen` (w or b). */
+  private fenColorAt(fen: string): PieceColor {
+    const parts = fen.split(' ');
+    return (parts[1] as PieceColor) || 'w';
   }
 
   async start(): Promise<GameState> {
@@ -392,6 +538,16 @@ export class GameRuntime {
             });
             moveApplied = true;
             this.replayMoveIndex++;
+
+            // Branch director: check whether a board branch is
+            // scheduled to fire AFTER this just-played main-line ply.
+            // The ply count includes priorMoveHistory + replayMoveIndex
+            // because both contribute to the canonical episode ply.
+            const mainPly = this.priorSanMoves.length + this.replayMoveIndex;
+            const branch = this.boardBranches.get(mainPly);
+            if (branch && !this.aborted) {
+              await this.executeBranch(branch, mainPly);
+            }
           } else {
             console.error(`[Replay] PGN move illegal: ${replaySan} at index ${this.replayMoveIndex}`);
             this.replayMoveIndex++;

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -589,6 +589,25 @@ export interface GameState {
   eventLog: import('./events').GameEvent[];
   // --- Taxonomy extensions ---
   gameClock?: { whiteRemainingMs: number; blackRemainingMs: number };
+  /**
+   * Active branch playback state. Non-null only while a board branch
+   * is executing (see docs/design-branch-playback.md). The displayed
+   * board switches to `currentBranchFen` and accumulates the branch
+   * moves in `moves` — independent of moveHistory, which stays on
+   * the main line.
+   */
+  activeBranch?: {
+    branchId: string;
+    title: string;
+    /** FEN BEFORE the first branch move (= where we rewound to). */
+    startingFen: string;
+    /** Current FEN within the branch (advances with each branch move). */
+    currentFen: string;
+    /** Branch moves played so far. */
+    moves: MoveRecord[];
+    /** Main-line ply we'll restore to when the branch ends. */
+    resumeMainPly: number;
+  } | null;
 }
 
 // --- UHO Opening Book ---

--- a/src/episodes/italian_game_lesson/index.ts
+++ b/src/episodes/italian_game_lesson/index.ts
@@ -1,4 +1,4 @@
-import type { Episode, MoveTangent, WhiteboardScene } from '../types';
+import type { Episode, MoveTangent, WhiteboardScene, BoardBranch } from '../types';
 import { ITALIAN_GAME_LESSON_PGN } from './pgn';
 import { ITALIAN_GAME_LESSON_COMMENTATOR } from './commentator';
 import { ITALIAN_GAME_VARIATIONS } from './variations';
@@ -35,6 +35,29 @@ const ITALIAN_GAME_TANGENTS: MoveTangent[] = [
     san: 'Bxf7+',
     category: 'student_mistake',
     note: 'Bxf7+ is the famous Italian sacrifice pattern but here it loses the bishop outright — ...Kxf7 and White has no follow-up. Castle first.',
+  },
+];
+
+// POC board branches — instructor-controlled "what if" interludes.
+// The lesson pauses after the chosen ply, plays the branch moves on
+// the actual board (with amber banner), then restores the main line.
+//
+// Italian Game branch: after Black plays 5...d6 (ply 10), the board
+// switches to "what if White tried Bxf7+ here?" — a famous student
+// blunder. The branch demonstrates that Black's king walks but White
+// has no follow-up, ending in a clearly losing position for White.
+// SANs validated legal against the main PGN's position after ply 10.
+const ITALIAN_GAME_BOARD_BRANCHES: BoardBranch[] = [
+  {
+    id: 'italian_bxf7_blunder',
+    afterPly: 10, // After 5...d6 (Black's 5th move), White to play
+    fromPly: 10, // No rewind — branch starts from the current position
+    title: '6.Bxf7+ — the bishop sacrifice that doesn\'t work',
+    branchMoves: ['Bxf7+', 'Kxf7', 'Ng5+', 'Kg8', 'Qh5+', 'g6'],
+    narrationCue:
+      "Show what happens if White tries the famous Bxf7+ sacrifice here instead of castling. The king walks but White has no follow-up — after Qh5+ g6 White is just down a bishop with no compensation. This is the most common reason club players LOSE games as White in the Italian: confusing the Fried Liver pattern (which needs ...Nxe5) with positions where it just hangs a piece.",
+    returnToPly: 10, // Resume main line at ply 11 (6.O-O)
+    branchMoveDelayMs: 1800,
   },
 ];
 
@@ -116,6 +139,7 @@ export const ITALIAN_GAME_LESSON_EPISODE: Episode = {
   commentator: ITALIAN_GAME_LESSON_COMMENTATOR,
   bookStandard: ITALIAN_GAME_BOOK_STANDARD,
   moveTangents: ITALIAN_GAME_TANGENTS,
+  boardBranches: ITALIAN_GAME_BOARD_BRANCHES,
   whiteboardScenes: ITALIAN_GAME_WHITEBOARD,
   exports: ITALIAN_GAME_EXPORT,
 };

--- a/src/episodes/types.ts
+++ b/src/episodes/types.ts
@@ -88,6 +88,18 @@ export interface Episode {
    */
   moveTangents?: MoveTangent[];
   /**
+   * Branch playback — alternative move sequences the lesson PLAYS on
+   * the actual board (not just shows as a ghost arrow). Each branch
+   * fires after a chosen main-line ply, rewinds to a starting FEN,
+   * plays N branch moves with their own narration, then restores the
+   * main-line position. Used for "what if X here?" interludes,
+   * blunder demonstrations, and explaining trap lines that need to
+   * be SEEN rather than described.
+   *
+   * See docs/design-branch-playback.md for the full design spec.
+   */
+  boardBranches?: BoardBranch[];
+  /**
    * Whiteboard scenes — full-frame educational slates that replace the
    * board view at authored plies. Used for content that doesn't read
    * well on a chess board: strategic principles, decision trees,
@@ -171,6 +183,71 @@ export interface MoveTangent {
    * here, that's because <note>").
    */
   note: string;
+}
+
+/**
+ * A board branch — an alternative line PLAYED on the actual board
+ * for instructional purposes. After the main line reaches `afterPly`,
+ * the lesson pauses, the board snaps to `startingFen` (often the same
+ * position the main line just reached, or a few plies earlier), the
+ * `branchMoves` play with their own narration, then the board
+ * restores to the main-line position and the lesson resumes.
+ *
+ * Branches are NOT recorded in the main move history — they live in
+ * a parallel `currentBranchMoves` array in GameState. Consumers
+ * (BroadcastLayout, recent moves panel) ignore branch moves for
+ * canonical-history rendering but use them to drive the branch
+ * overlay UI.
+ *
+ * See docs/design-branch-playback.md for design rationale.
+ */
+export interface BoardBranch {
+  /** Stable id, e.g. 'italian_fried_liver'. Used to scope events. */
+  id: string;
+  /**
+   * 1-indexed ply AFTER which this branch plays. Lesson finishes
+   * narrating move `afterPly`, then the branch fires.
+   */
+  afterPly: number;
+  /**
+   * 1-indexed main-line ply that defines the position to rewind to
+   * before playing branchMoves. Default = afterPly (no rewind — branch
+   * starts from the current position). Set lower to rewind, e.g.
+   * "what if Black had played X 2 moves ago?" → fromPly = afterPly - 2.
+   */
+  fromPly?: number;
+  /**
+   * SAN move sequence to play from the startingFen. 3-8 moves is the
+   * sweet spot; longer branches lose viewer attention. Validated at
+   * mount against the main PGN's position before fromPly.
+   */
+  branchMoves: string[];
+  /**
+   * One-paragraph narration cue spliced into the commentator prompt
+   * during the branch. Tells the LLM the educational point of THIS
+   * branch ("show what happens after Bxf7+: Black walks the king
+   * but White has no follow-up — Black is up a piece").
+   */
+  narrationCue: string;
+  /**
+   * 1-indexed main-line ply to resume at after the branch ends.
+   * Default = afterPly (no skip — main line resumes from where it
+   * paused). Set higher to skip ahead, e.g. branch covers moves
+   * 8-12 hypothetically and main line resumes at 12.
+   */
+  returnToPly?: number;
+  /**
+   * Wall-clock delay between each branch move (ms). Default 1800 —
+   * a touch faster than the main line's narration-gated pace so the
+   * branch reads as a tight hypothetical interlude, not a parallel
+   * lesson.
+   */
+  branchMoveDelayMs?: number;
+  /**
+   * Banner title shown during the branch (e.g. "Blunder Line: 7.Bxf7+
+   * loses the bishop"). Empty string = no banner.
+   */
+  title?: string;
 }
 
 /**

--- a/src/store/tournamentStore.ts
+++ b/src/store/tournamentStore.ts
@@ -155,7 +155,7 @@ interface TournamentStore {
   resumeGame: (matchIndex: number, pairIndex: number, slotIndex: 0 | 1) => void;
 
   // Replay actions
-  startReplay: (pgn: string, config: { historicalContext?: string; lessonContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean }) => void;
+  startReplay: (pgn: string, config: { historicalContext?: string; lessonContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean; boardBranches?: import('../episodes/types').BoardBranch[] }) =>void;
   stopReplay: () => void;
 
   // Multi-tournament actions
@@ -641,7 +641,7 @@ export const useTournamentStore = create<TournamentStore>()(
 
       // --- Replay actions ---
 
-      startReplay: (pgn: string, config: { historicalContext?: string; lessonContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean }) => {
+      startReplay: (pgn: string, config: { historicalContext?: string; lessonContext?: string; moveDelayMs?: number; startFromPly?: number; paceWithNarration?: boolean; boardBranches?: import('../episodes/types').BoardBranch[] }) =>{
         const { activeRuntime } = get();
         if (activeRuntime) {
           activeRuntime.abort('Starting replay');
@@ -739,6 +739,25 @@ export const useTournamentStore = create<TournamentStore>()(
             }
             if (_waitForNarration) {
               try { await _waitForNarration(); } catch { /* same */ }
+            }
+          });
+        }
+
+        // Wire board branches: when the main line hits an authored
+        // ply, the runtime pauses and plays the branch on the board.
+        // The narration hook lets the commentator generate the
+        // branch's spoken context BEFORE branch moves fire, so the
+        // audio leads the visuals — same pattern as the futures/outro
+        // sequence in the post-game .then() block.
+        if (config.boardBranches && config.boardBranches.length > 0) {
+          runtime.setBoardBranches(config.boardBranches);
+          runtime.setBranchNarrationHook(async (branch, startingFen) => {
+            if (!_commentaryQueue) return;
+            try {
+              await _commentaryQueue.generateBranch(branch, startingFen);
+              if (_waitForNarration) await _waitForNarration();
+            } catch (err) {
+              console.warn('[Replay] branch narration failed — branch will play silently:', err);
             }
           });
         }


### PR DESCRIPTION
## Summary

Implements [`docs/design-branch-playback.md`](docs/design-branch-playback.md) — alternative move sequences PLAYED on the actual board (not just ghosted as arrows). The lesson can pause after any ply, snap the board to a starting position, play 3-8 branch moves with their own narration, then restore the main line.

The user framing:
> \"we need the ability for the instructor to control board state with more granularity. to roll back the game and explore different ideas, etc\"

## How it looks

When a branch fires, the board:
- Switches FEN to the branch starting position (snap, no animation in v1)
- Plays each branch move with ~1.8s between (configurable per branch)
- Gets a 4px amber ring + the chapter header is overlaid with \"BRANCH · Hypothetical Line\" banner + branch title
- Restores to the main-line position on \`BranchEnded\`, ring + banner clear

## Engine

| File | Change |
|---|---|
| [`events.ts`](src/engine/events.ts) | + 3 events: \`BranchStarted\`, \`BranchMoveApplied\`, \`BranchEnded\` |
| [`types.ts`](src/engine/types.ts) | + \`GameState.activeBranch\` ({ branchId, title, startingFen, currentFen, moves[], resumeMainPly }) |
| [`reducer.ts`](src/engine/reducer.ts) | + handles the 3 events; \`BranchEnded\` restores main FEN and clears \`activeBranch\` |
| [`runtime.ts`](src/engine/runtime.ts) | + \`setBoardBranches()\` registers branches by \`afterPly\` |
| | + \`setBranchNarrationHook()\` lets the commentary queue lead audio before branch moves fire |
| | + \`executeBranch()\` saves main FEN, runs the branch with delays, restores. Replay loop fires it after each main move. |
| [`commentaryQueue.ts`](src/commentary/commentaryQueue.ts) | + \`generateBranch(branch, startingFen)\` — single narration block opening the branch (2-3 sentences) |
| [`tournamentStore.ts`](src/store/tournamentStore.ts) | + \`startReplay\` accepts \`boardBranches\`; wires the runtime + narration hook |
| [`BroadcastView.tsx`](src/components/BroadcastView.tsx) | + forwards \`episode.boardBranches\` to \`startReplay\` (skipped for variation captures) |
| [`BroadcastLayout.tsx`](src/components/BroadcastLayout.tsx) | + reads \`activeBranch\` from \`GameState\`; switches \`displayedFen\` to branch FEN, overlays banner, adds amber board ring. Both \`FullLayout\` and \`MultiModalLayout\`. |

## POC (Italian Game)

One authored branch at ply 10 (after \`5...d6\`):

\`\`\`
6.Bxf7+ Kxf7 7.Ng5+ Kg8 8.Qh5+ g6
\`\`\`

The classic student blunder — White hopes the Fried Liver pattern works in the Giuoco Piano but ends up just down a bishop. SANs validated legal against the main PGN's position before the branch fires.

## Backwards compatible

Episodes without \`boardBranches\` behave identically. Only the replay player consults the branch map; non-broadcast game flow is untouched.

## Test plan

- [x] Typecheck clean
- [x] Italian branch SANs validate vs main PGN
- [ ] Smoke-capture \`italian_game_lesson\` and verify the branch fires after ply 10 with banner + ring + 6 visible branch moves
- [ ] Confirm main line resumes at ply 11 (\`6.O-O\`) after the branch ends
- [ ] Confirm narration leads visuals (branch audio starts during chess.js load + first branch move)

## Follow-ups (v2)

- Per-branch-move commentary (currently one block opens the branch)
- Nested branches (branch within a branch) — design doc marks as YAGNI for v1
- Branch eval bar — currently freezes at main-line eval; could update to branch position

🤖 Generated with [Claude Code](https://claude.com/claude-code)