### PR TITLE
fix(mp4-export): bump capture timeout 60→120 min + revert KID gpt-4.1

### DIFF
--- a/scripts/export-london-then-kid.mjs
+++ b/scripts/export-london-then-kid.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Sequential capture of London System + King's Indian Defense.
+ * Both landscape-only at the new bitrate / multi-modal layout.
+ * Estimated wallclock: ~30-40 min total.
+ */
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function run(args) {
+  return new Promise((resolve) => {
+    console.log(`\n========== ${args.join(' ')} ==========`);
+    const child = spawn('npm', ['run', 'export:game', '--', ...args], {
+      cwd: repoRoot, stdio: 'inherit', shell: true, windowsHide: true,
+    });
+    child.on('exit', (code) => resolve(code ?? 1));
+  });
+}
+
+const episodes = ['london_system_lesson', 'kings_indian_classical_lesson'];
+const start = Date.now();
+for (const ep of episodes) {
+  const t0 = Date.now();
+  console.log(`\n[batch] starting ${ep} at ${new Date().toISOString()}`);
+  const code = await run(['--episode', ep, '--landscape-only']);
+  const mins = ((Date.now() - t0) / 60000).toFixed(1);
+  console.log(`[batch] ${ep} ${code === 0 ? 'OK' : 'FAILED (' + code + ')'} in ${mins} min`);
+}
+console.log(`\n[batch] all done in ${((Date.now() - start) / 60000).toFixed(1)} min`);

--- a/scripts/lib/export/browserCapture.ts
+++ b/scripts/lib/export/browserCapture.ts
@@ -355,11 +355,24 @@ async function waitForPlaybackEnd(page: Page, options: CaptureOptions): Promise<
     await Promise.race([donePromise, page.waitForTimeout(options.previewDurationMs)]);
     return;
   }
-  // Game-review captures: be generous with the timeout. A Morphy
-  // game is ~3 minutes of moves but commentary at high reasoning
-  // effort can easily push 30 minutes. The default 60-minute ceiling
-  // is intentionally large; override via endTimeoutMs.
-  const timeout = options.endTimeoutMs ?? 60 * 60_000;
+  // Game-review captures: be generous with the timeout.
+  //
+  // Sizing rationale:
+  //   - A bare Morphy game is ~3 minutes of moves but high-reasoning
+  //     commentary can push it to 25-30 minutes.
+  //   - Fully-featured lessons (multi-modal layout + 3-4 board
+  //     branches + 3-4 whiteboard scenes + ghost arrows + book
+  //     standard + futures + outro) easily run 45-75 minutes:
+  //     · Each branch interlude ~60-120s (narration + 4-6 moves)
+  //     · Each whiteboard scene ~12-15s narrated
+  //     · Final-position-plus-futures + outro ~3-4 min
+  //   - London (gpt-5.5 commentary, 4 branches, 4 whiteboards)
+  //     timed out at 60 min on 2026-05-28; bump to 120 min.
+  //
+  // Override via endTimeoutMs. Should match the launching node
+  // process's own timeout to avoid the orchestrator dying before
+  // the capture completes.
+  const timeout = options.endTimeoutMs ?? 120 * 60_000;
   await page.waitForFunction(
     () => Boolean(window.__CHESS_EXPORT__?.state().ended),
     undefined,

--- a/src/episodes/kings_indian_classical_lesson/commentator.ts
+++ b/src/episodes/kings_indian_classical_lesson/commentator.ts
@@ -2,7 +2,6 @@ import { DEFAULT_COMMENTATOR, type EpisodeCommentatorConfig } from '../types';
 
 export const KINGS_INDIAN_CLASSICAL_LESSON_COMMENTATOR: EpisodeCommentatorConfig = {
   ...DEFAULT_COMMENTATOR,
-  model: 'gpt-4.1',
   lessonContext: [
     'Lesson topic: the King\'s Indian Defense, Classical Variation Mar del Plata main line.',
     'You are an AI teacher demonstrating the opening to a chess student who knows classical openings (1.e4 e5, QGD) but is new to hypermodern strategy.',


### PR DESCRIPTION
London capture timed out at exactly 60 min in the middle of a branch interlude. Bumping the ceiling to 120 min for fully-featured lessons. Also reverting KID's gpt-4.1 swap back to default gpt-5.5 for cross-episode consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended export capture timeout to improve reliability for large content batches.
  * Updated internal export configuration and tooling to streamline content processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->