### PR TITLE
feat(broadcast): per-branch-move narration + Line-on-board switches to branch

### DIFF
--- a/src/commentary/commentaryQueue.ts
+++ b/src/commentary/commentaryQueue.ts
@@ -631,6 +631,130 @@ Do NOT walk through every branch move individually — the board does that visua
     }
   }
 
+  /**
+   * Generate narration for ONE branch move as it's about to be played
+   * on the board. The runtime calls this BEFORE applying each branch
+   * move so the audio leads the visual. Short (1-2 sentences), in the
+   * commentator's teaching voice, focused on WHY this specific move
+   * follows in the branch.
+   *
+   * Distinct from generateBranch (which produces the branch-OPENING
+   * narration) — this fires per move so the branch isn't a silent
+   * pass-through, which the user flagged as "the fundamental value of
+   * the video" on 2026-05-28.
+   */
+  async generateBranchMove(params: {
+    branchId: string;
+    branchTitle: string;
+    branchPly: number;
+    san: string;
+    color: 'w' | 'b';
+    fenBefore: string;
+    branchNarrationCue: string;
+  }): Promise<void> {
+    if (this.destroyed) return;
+    const model = this.config.getCommentatorModel();
+    if (!model.id) return;
+    console.log('[Commentary] generateBranchMove %s ply=%d: %s', params.branchId, params.branchPly, params.san);
+
+    this.active = [];
+
+    const entry: CommentaryEntry = {
+      id: genId(),
+      moves: [],
+      text: '',
+      streaming: true,
+      timestamp: Date.now(),
+      maxMoveIndex: -1,
+      isFiller: true,
+    };
+    this.entries = [...this.entries, entry];
+    const entryIndex = this.entries.length - 1;
+    this.emit();
+    let abortCtrl: AbortController | null = null;
+
+    const ttsMode = this.config.getTtsMode?.() ?? false;
+    const colorWord = params.color === 'w' ? 'White' : 'Black';
+    // Branch moves are core lesson content — narrate them with the
+    // same depth as main-line commentary. Per user direction
+    // 2026-05-28: "branches are all core part of the video's magic
+    // AI tutor. That AI tutor has full control and responsibility
+    // for conveying the lesson to the student without skipping over
+    // anything... Chess isn't magically always one line and no plan
+    // survives a punch in the face."
+    const prompt = `You are teaching a chess lesson and currently demonstrating an alternative line titled "${params.branchTitle}".
+
+Why this line matters: ${params.branchNarrationCue}
+
+Position FEN BEFORE this move: ${params.fenBefore}
+You are about to play: ${colorWord}'s ${params.san} (move ${params.branchPly} of the alternative line)
+
+Narrate this move the same way you'd narrate any main-lesson move: explain what it does, why it's the natural follow-up in THIS line, and what idea, threat, or principle it demonstrates. 1-3 spoken sentences. Speak in first person — you are playing both sides ("I play ${params.san}…").
+
+${ttsMode ? 'Spoken naturally, no markdown.' : 'Use plain prose, no markdown headers.'}
+
+Do NOT recap the whole branch. Do NOT introduce yourself. Do NOT mention "the video", "the viewer", or "the audience". Treat this move with the same care as a main-line move — every move in chess teaching matters; nothing is a silent pass-through.`;
+
+    try {
+      const client = this.config.getClient();
+      abortCtrl = new AbortController();
+      this.activeGenerationAbort = abortCtrl;
+
+      const messages: import('../llm/prompts').ChatMessage[] = [
+        {
+          role: 'system',
+          content:
+            this.config.systemPromptOverride ??
+            `You are a chess instructor narrating one move at a time inside a hypothetical alternative line.${ttsMode ? ' Spoken natural language only, no markdown.' : ''}`,
+        },
+        { role: 'user', content: prompt },
+      ];
+
+      // Branch moves get the SAME token budget as main-line commentary
+      // — they're not tweet-sized blurbs, they're real teaching beats.
+      const result = await runResilientTextGeneration({
+        client,
+        model: model.id,
+        messages,
+        temperature: 0.7,
+        responseOptions: {
+          promptLevel: 'p0',
+          maxTokens: model.maxTokens ?? 400,
+          reasoningEffort: model.reasoningEffort,
+        },
+        abortSignal: abortCtrl.signal,
+        onText: (text) => this.updateEntryText(entryIndex, text),
+        stallTimeoutMs: 30000,
+        hardTimeoutMs: 90000,
+        maxAttempts: 2,
+      });
+      if (this.activeGenerationAbort === abortCtrl) {
+        this.activeGenerationAbort = null;
+      }
+      this.active = null;
+      this.completeEntry(
+        entryIndex,
+        result.text || `${colorWord} plays ${params.san}.`,
+        true,
+      );
+    } catch (err) {
+      if (abortCtrl?.signal.aborted) {
+        if (this.activeGenerationAbort === abortCtrl) {
+          this.activeGenerationAbort = null;
+        }
+        this.active = null;
+        return;
+      }
+      if (this.activeGenerationAbort === abortCtrl) {
+        this.activeGenerationAbort = null;
+      }
+      this.active = null;
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn('[Commentary] BranchMove %s ply=%d failed: %s', params.branchId, params.branchPly, message);
+      this.completeEntry(entryIndex, `${colorWord} plays ${params.san}.`, true);
+    }
+  }
+
   enqueue(item: QueuedMove): void {
     if (this.destroyed) return;
     this.moveTimestamps.push(Date.now());

--- a/src/components/BroadcastLayout.tsx
+++ b/src/components/BroadcastLayout.tsx
@@ -260,26 +260,68 @@ export function BroadcastLayout({
     if (!activeChapter || !whatToWatch) return null;
     return whatToWatch.find((b) => b.chapterPly === activeChapter.ply)?.text ?? null;
   }, [activeChapter, whatToWatch]);
-  // Full move list — every ply of the parsed PGN with the current
-  // ply highlighted. Pairs white+black moves into rows.
-  const fullMoveList = useMemo(() => {
+  // Build a paired-row move list from a sequence of {san, color}.
+  // Reused for both the main PGN and an active branch's moves.
+  const buildPairedMoveList = (
+    moves: { san: string; color: 'w' | 'b' }[],
+    startTurnNumber = 1,
+    startColor: 'w' | 'b' = 'w',
+  ): { num: number; white?: string; black?: string; whitePly?: number; blackPly?: number }[] => {
     const pairs: { num: number; white?: string; black?: string; whitePly?: number; blackPly?: number }[] = [];
-    for (let i = 0; i < pgnMoves.length; i++) {
-      const move = pgnMoves[i];
-      const ply = i + 1;
-      const turnNum = Math.ceil(ply / 2);
+    for (let i = 0; i < moves.length; i++) {
+      const m = moves[i];
+      const ply = i + 1; // ply within the supplied sequence
+      // turnNumber for the row: starts at startTurnNumber for the
+      // first WHITE move, increments after each full turn.
+      let turnNum: number;
+      if (startColor === 'w') {
+        turnNum = startTurnNumber + Math.floor(i / 2);
+      } else {
+        // First move is Black — pair up with a phantom White slot.
+        turnNum = startTurnNumber + Math.floor((i + 1) / 2);
+      }
       const last = pairs[pairs.length - 1];
-      if (move.color === 'w') {
-        pairs.push({ num: turnNum, white: move.san, whitePly: ply });
+      if (m.color === 'w') {
+        pairs.push({ num: turnNum, white: m.san, whitePly: ply });
       } else if (last && last.num === turnNum && last.white !== undefined) {
-        last.black = move.san;
+        last.black = m.san;
         last.blackPly = ply;
       } else {
-        pairs.push({ num: turnNum, black: move.san, blackPly: ply });
+        pairs.push({ num: turnNum, black: m.san, blackPly: ply });
       }
     }
     return pairs;
+  };
+
+  // Full move list — every ply of the parsed PGN with the current
+  // ply highlighted. Pairs white+black moves into rows.
+  const fullMoveList = useMemo(() => {
+    return buildPairedMoveList(
+      pgnMoves.map((m) => ({ san: m.san, color: m.color })),
+    );
   }, [pgnMoves]);
+
+  // Branch move list — when a board branch is mid-playback, the
+  // Line-on-board panel switches to show the branch's moves instead
+  // of the main PGN. The currently-active branch ply is highlighted
+  // so the viewer can read along with the board changes (which were
+  // otherwise playing silently with no in-frame text reference —
+  // 2026-05-28 user feedback on the London capture at 2:42 in).
+  const branchMoveList = useMemo(() => {
+    if (!gameState.activeBranch || gameState.activeBranch.moves.length === 0) return null;
+    // Determine starting turn number + side-to-move from the branch's
+    // startingFen so the move numbering matches what the viewer sees
+    // (e.g. branch starting at main ply 5 shows as "3...").
+    const fenParts = gameState.activeBranch.startingFen.split(' ');
+    const startColor = (fenParts[1] as 'w' | 'b') || 'w';
+    const fullmoveNumber = Number(fenParts[5]) || 1;
+    return buildPairedMoveList(
+      gameState.activeBranch.moves.map((m) => ({ san: m.move, color: m.color as 'w' | 'b' })),
+      fullmoveNumber,
+      startColor,
+    );
+  }, [gameState.activeBranch]);
+  const branchActivePly = gameState.activeBranch?.moves.length ?? 0;
   // Fun fact rotator — picks the fact valid for currentPly that has
   // rotated to "now". For v1 we slice by `floor(currentPly / 4)`
   // so a new fact shows every ~4 plies (~2 minutes at lesson pace).
@@ -311,6 +353,11 @@ export function BroadcastLayout({
     />;
   }
   if (useMultiModal && activeChapter) {
+    // When mid-branch, the Line-on-board panel shows the branch's
+    // moves with its own active-ply highlight. Otherwise it shows the
+    // main PGN — same data as before.
+    const displayedMoveList = activeBranch && branchMoveList ? branchMoveList : fullMoveList;
+    const displayedActivePly = activeBranch ? branchActivePly : currentPly;
     return <MultiModalLayout
       displayedFen={displayedFen}
       lastMove={displayedLastMove}
@@ -326,8 +373,8 @@ export function BroadcastLayout({
       totalChapters={(chapters?.length ?? 0)}
       activeKeyIdeas={activeKeyIdeas}
       activeWhatToWatch={activeWhatToWatch}
-      fullMoveList={fullMoveList}
-      activePly={currentPly}
+      fullMoveList={displayedMoveList}
+      activePly={displayedActivePly}
       activeFunFact={activeFunFact}
       activeBranch={activeBranch}
     />;

--- a/src/engine/runtime.ts
+++ b/src/engine/runtime.ts
@@ -72,6 +72,24 @@ export class GameRuntime {
   private branchNarrationHook:
     | ((branch: BoardBranch, startingFen: string) => Promise<void>)
     | null = null;
+  /**
+   * Optional hook called BEFORE each individual branch move plays.
+   * The commentary queue uses this to generate + narrate a one-line
+   * explanation of what THIS move does — so branches don't rip
+   * through silently after the opening narration.
+   *
+   * Awaited before the move is applied; the move + delay only happen
+   * once the narration audio completes.
+   */
+  private branchMoveNarrationHook:
+    | ((params: {
+        branch: BoardBranch;
+        branchPly: number;
+        san: string;
+        color: PieceColor;
+        fenBefore: string;
+      }) => Promise<void>)
+    | null = null;
 
   constructor(
     white: PlayerConfig,
@@ -204,6 +222,24 @@ export class GameRuntime {
   }
 
   /**
+   * Set the per-branch-move narration hook. The runtime awaits this
+   * before applying each branch move, so each branch move gets its
+   * own spoken explanation (instead of a silent pass-through after
+   * the branch opening).
+   */
+  setBranchMoveNarrationHook(
+    fn: ((params: {
+      branch: BoardBranch;
+      branchPly: number;
+      san: string;
+      color: PieceColor;
+      fenBefore: string;
+    }) => Promise<void>) | null,
+  ): void {
+    this.branchMoveNarrationHook = fn;
+  }
+
+  /**
    * Execute a branch: emit BranchStarted, rewind board to startingFen,
    * play each branch move (validating via chess.js, awaiting the move
    * delay between each), then emit BranchEnded and restore the main
@@ -248,6 +284,7 @@ export class GameRuntime {
     this.chess.load(startingFen);
 
     const delay = branch.branchMoveDelayMs ?? 1800;
+    const startColor = this.fenColorAt(startingFen);
     for (let i = 0; i < branch.branchMoves.length; i++) {
       if (this.aborted) break;
       const san = branch.branchMoves[i];
@@ -258,6 +295,30 @@ export class GameRuntime {
         );
         break;
       }
+      const fenBefore = this.chess.fen();
+      const moveColor: PieceColor =
+        i % 2 === 0 ? startColor : startColor === 'w' ? 'b' : 'w';
+
+      // Narrate this branch move BEFORE applying it. Pacing is gated on
+      // narration completion — no arbitrary delay between moves.
+      if (this.branchMoveNarrationHook) {
+        try {
+          await this.branchMoveNarrationHook({
+            branch,
+            branchPly: i + 1,
+            san: validation.san!,
+            color: moveColor,
+            fenBefore,
+          });
+        } catch (err) {
+          console.warn(
+            `[Branch ${branch.id}] per-move narration hook threw at ply ${i + 1} — continuing:`,
+            err,
+          );
+        }
+      }
+      if (this.aborted) break;
+
       const moveResult = this.chess.applyMove(validation.san!);
       const isCheckmate = this.chess.isGameOver() && this.chess.fen().includes('#'); // best-effort
       this.emit({
@@ -265,7 +326,7 @@ export class GameRuntime {
         payload: {
           branchId: branch.id,
           branchPly: i + 1,
-          color: i % 2 === 0 ? (this.fenColorAt(startingFen) === 'w' ? 'w' : 'b') : this.fenColorAt(startingFen) === 'w' ? 'b' : 'w',
+          color: moveColor,
           san: validation.san!,
           from: moveResult.from,
           to: moveResult.to,
@@ -275,7 +336,14 @@ export class GameRuntime {
           isCapture: moveResult.captured !== undefined,
         },
       });
-      if (i < branch.branchMoves.length - 1 && !this.aborted) {
+
+      // Without a narration hook, fall back to the legacy fixed delay so
+      // the board doesn't snap through positions instantly.
+      if (
+        !this.branchMoveNarrationHook &&
+        i < branch.branchMoves.length - 1 &&
+        !this.aborted
+      ) {
         await new Promise((r) => setTimeout(r, delay));
       }
     }

--- a/src/store/tournamentStore.ts
+++ b/src/store/tournamentStore.ts
@@ -760,6 +760,26 @@ export const useTournamentStore = create<TournamentStore>()(
               console.warn('[Replay] branch narration failed — branch will play silently:', err);
             }
           });
+          runtime.setBranchMoveNarrationHook(async ({ branch, branchPly, san, color, fenBefore }) => {
+            if (!_commentaryQueue) return;
+            try {
+              await _commentaryQueue.generateBranchMove({
+                branchId: branch.id,
+                branchTitle: branch.title ?? '',
+                branchPly,
+                san,
+                color,
+                fenBefore,
+                branchNarrationCue: branch.narrationCue,
+              });
+              if (_waitForNarration) await _waitForNarration();
+            } catch (err) {
+              console.warn(
+                `[Replay] branch per-move narration failed at ply ${branchPly} — move will play silently:`,
+                err,
+              );
+            }
+          });
         }
 
         runtime.subscribe((state: GameState, event: GameEvent) => {


### PR DESCRIPTION
## Summary
- Branches are core lesson content — the AI tutor explains every branch move with main-line depth, no more silent rip-through after the branch opening cue.
- `CommentaryQueue.generateBranchMove`: full lesson-quality prompt (1-3 sentences on what the move does + why it's natural here + idea/threat/principle), main-line token budget + timeouts.
- `runtime.executeBranch`: awaits `branchMoveNarrationHook` BEFORE applying each branch move. Narration completion gates pacing (no more arbitrary 1.8s delay); legacy fixed delay only when no hook is wired.
- `tournamentStore`: wires `setBranchMoveNarrationHook` alongside the existing branch-opening hook.
- `BroadcastLayout`: Line-on-board panel switches to the branch's paired move list with branch-relative active ply while a branch plays, so the on-screen move list tracks what the viewer is watching.

Fixes the reported regression: "at 2:42 the board starts moving in the background with no supporting line on board animation, or narration, its just changing states rapidly through multiple board configurations."

## Test plan
- [ ] Typecheck (`npx tsc --noEmit`) — passes locally.
- [ ] Re-capture London System lesson; verify each branch move is narrated and Line-on-board panel tracks the branch.
- [ ] Re-capture King's Indian Classical; same check.
- [ ] Confirm main-line move pacing/narration is unchanged (regression check on `replayPaceCheck` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)