### PR TITLE
fix(broadcast): branch beats — board leads audio, snap-back waits for closing

### DIFF
--- a/src/engine/events.ts
+++ b/src/engine/events.ts
@@ -206,8 +206,30 @@ export interface BranchStartedEvent extends BaseEvent {
     fromMainPly: number;
     /** FEN we'll rewind to before playing branchMoves[]. */
     startingFen: string;
+    /**
+     * FEN of the main-line position at the moment the branch fired.
+     * The board renders THIS while the opening narration plays so the
+     * viewer sees "here's where we are; let me show you an alternative"
+     * with full context before the rewind. The rewind to startingFen
+     * happens on `BranchPositionRewound`, after the opening narration.
+     */
+    mainLineFen: string;
     /** Display title for the banner overlay. Empty string = no banner. */
     title: string;
+  };
+}
+
+/**
+ * Emitted AFTER the branch's opening narration finishes but BEFORE
+ * the per-move loop begins. The board snaps to the branch's
+ * `startingFen` on this event — giving the viewer the rewind only
+ * after they've heard the framing.
+ */
+export interface BranchPositionRewoundEvent extends BaseEvent {
+  type: 'BranchPositionRewound';
+  payload: {
+    branchId: string;
+    startingFen: string;
   };
 }
 
@@ -254,6 +276,7 @@ export type GameEvent =
   | GameAbortedEvent
   | ErrorOccurredEvent
   | BranchStartedEvent
+  | BranchPositionRewoundEvent
   | BranchMoveAppliedEvent
   | BranchEndedEvent;
 

--- a/src/engine/reducer.ts
+++ b/src/engine/reducer.ts
@@ -143,17 +143,32 @@ export function gameReducer(state: GameState, event: GameEvent): GameState {
     // ───────────────────────────────────────────────────────
 
     case 'BranchStarted':
+      // The board stays on the main-line position while the opening
+      // narration plays — giving the viewer the framing BEFORE the
+      // visual rewind. The actual rewind to startingFen happens on
+      // the BranchPositionRewound event below, after the narration.
       return {
         ...withEvent,
         activeBranch: {
           branchId: event.payload.branchId,
           title: event.payload.title,
           startingFen: event.payload.startingFen,
-          currentFen: event.payload.startingFen,
+          currentFen: event.payload.mainLineFen,
           moves: [],
           resumeMainPly: event.payload.fromMainPly,
         },
       };
+
+    case 'BranchPositionRewound': {
+      if (!state.activeBranch) return withEvent;
+      return {
+        ...withEvent,
+        activeBranch: {
+          ...state.activeBranch,
+          currentFen: event.payload.startingFen,
+        },
+      };
+    }
 
     case 'BranchMoveApplied': {
       if (!state.activeBranch) return withEvent;

--- a/src/engine/runtime.ts
+++ b/src/engine/runtime.ts
@@ -289,11 +289,16 @@ export class GameRuntime {
         branchId: branch.id,
         fromMainPly: mainPly,
         startingFen,
+        // Board renders THIS during the opening narration so the
+        // viewer hears the framing on the main-line position before
+        // the rewind. BranchPositionRewound (below) snaps to startingFen.
+        mainLineFen: mainFenBeforeBranch,
         title: branch.title ?? '',
       },
     });
 
-    // Let the commentary queue lead with branch narration.
+    // Opening narration plays with board still on main line —
+    // context first, then the visual rewind.
     if (this.branchNarrationHook) {
       try {
         await this.branchNarrationHook(branch, startingFen);
@@ -303,8 +308,12 @@ export class GameRuntime {
     }
     if (this.aborted) return;
 
-    // Rewind the chess.js board.
+    // Rewind the chess.js board AND notify the UI to snap the board.
     this.chess.load(startingFen);
+    this.emit({
+      type: 'BranchPositionRewound',
+      payload: { branchId: branch.id, startingFen },
+    });
 
     const delay = branch.branchMoveDelayMs ?? 1800;
     const startColor = this.fenColorAt(startingFen);
@@ -322,26 +331,11 @@ export class GameRuntime {
       const moveColor: PieceColor =
         i % 2 === 0 ? startColor : startColor === 'w' ? 'b' : 'w';
 
-      // Narrate this branch move BEFORE applying it. Pacing is gated on
-      // narration completion — no arbitrary delay between moves.
-      if (this.branchMoveNarrationHook) {
-        try {
-          await this.branchMoveNarrationHook({
-            branch,
-            branchPly: i + 1,
-            san: validation.san!,
-            color: moveColor,
-            fenBefore,
-          });
-        } catch (err) {
-          console.warn(
-            `[Branch ${branch.id}] per-move narration hook threw at ply ${i + 1} — continuing:`,
-            err,
-          );
-        }
-      }
-      if (this.aborted) break;
-
+      // Apply the move FIRST so the board reflects what's about to
+      // be narrated. This matches main-line pacing (move → engine
+      // think dead air → narration). The previous "narrate first,
+      // then apply" caused the board to lag the audio by a full
+      // narration cycle (~15-20s).
       const moveResult = this.chess.applyMove(validation.san!);
       const isCheckmate = this.chess.isGameOver() && this.chess.fen().includes('#'); // best-effort
       this.emit({
@@ -359,6 +353,27 @@ export class GameRuntime {
           isCapture: moveResult.captured !== undefined,
         },
       });
+
+      // Now narrate with the board on the post-move position. The
+      // narration prompt still receives fenBefore so the LLM can
+      // analyze the move that was just played.
+      if (this.branchMoveNarrationHook) {
+        try {
+          await this.branchMoveNarrationHook({
+            branch,
+            branchPly: i + 1,
+            san: validation.san!,
+            color: moveColor,
+            fenBefore,
+          });
+        } catch (err) {
+          console.warn(
+            `[Branch ${branch.id}] per-move narration hook threw at ply ${i + 1} — continuing:`,
+            err,
+          );
+        }
+      }
+      if (this.aborted) break;
 
       // Without a narration hook, fall back to the legacy fixed delay so
       // the board doesn't snap through positions instantly.

--- a/src/store/tournamentStore.ts
+++ b/src/store/tournamentStore.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 import { GameRuntime } from '../engine/runtime';
 import { Chess } from 'chess.js';
 import { parseSinglePgn, pgnResultToGameResult } from '../pgn/parser';
+import { getActiveAudioNarrationQueue } from '../tts/audio-queue';
 import type {
   CommentatorConfig,
   EvalLogEntry,
@@ -751,11 +752,26 @@ export const useTournamentStore = create<TournamentStore>()(
         // sequence in the post-game .then() block.
         if (config.boardBranches && config.boardBranches.length > 0) {
           runtime.setBoardBranches(config.boardBranches);
+          // Helper: gate the runtime on a newly-completed commentary entry
+          // ACTUALLY reaching the audio queue and finishing playback.
+          // Without waitForEntryCount, _waitForNarration races with React's
+          // useEffect that enqueues the completed entry — the queue is still
+          // idle at the moment of the call, so waitUntilDone returns
+          // immediately and the runtime advances before audio plays.
+          const drainNewNarration = async () => {
+            const audioQueue = getActiveAudioNarrationQueue();
+            if (audioQueue) {
+              const target = audioQueue.backlogEntries + 1;
+              await audioQueue.waitForEntryCount(target, 3000);
+            }
+            if (_waitForNarration) await _waitForNarration();
+          };
+
           runtime.setBranchNarrationHook(async (branch, startingFen) => {
             if (!_commentaryQueue) return;
             try {
               await _commentaryQueue.generateBranch(branch, startingFen);
-              if (_waitForNarration) await _waitForNarration();
+              await drainNewNarration();
             } catch (err) {
               console.warn('[Replay] branch narration failed — branch will play silently:', err);
             }
@@ -772,7 +788,7 @@ export const useTournamentStore = create<TournamentStore>()(
                 fenBefore,
                 branchNarrationCue: branch.narrationCue,
               });
-              if (_waitForNarration) await _waitForNarration();
+              await drainNewNarration();
             } catch (err) {
               console.warn(
                 `[Replay] branch per-move narration failed at ply ${branchPly} — move will play silently:`,
@@ -790,7 +806,7 @@ export const useTournamentStore = create<TournamentStore>()(
                 finalFen,
                 branchNarrationCue: branch.narrationCue,
               });
-              if (_waitForNarration) await _waitForNarration();
+              await drainNewNarration();
             } catch (err) {
               console.warn(
                 `[Replay] branch closing narration failed — snap-back will be silent:`,

--- a/src/tts/audio-queue.ts
+++ b/src/tts/audio-queue.ts
@@ -381,6 +381,33 @@ export class AudioNarrationQueue {
     });
   }
 
+  /**
+   * Wait until the queue has received at least `targetEntryCount`
+   * total entries via enqueue/enqueueEntry, OR `timeoutMs` elapses.
+   * Closes a React-render race: when a commentary entry completes,
+   * CommentaryPanel's effect needs a render tick to call enqueueEntry.
+   * If the runtime calls waitUntilDone immediately, it sees an idle
+   * queue and returns before the new entry is even queued. Pair this
+   * with waitUntilDone (call it first, then waitUntilDone) to make
+   * narration gating reliable.
+   */
+  waitForEntryCount(targetEntryCount: number, timeoutMs = 3000): Promise<void> {
+    if (this._entryCount >= targetEntryCount) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const start = Date.now();
+      const check = () => {
+        if (this._entryCount >= targetEntryCount) {
+          resolve();
+        } else if (Date.now() - start >= timeoutMs) {
+          resolve();
+        } else {
+          setTimeout(check, 50);
+        }
+      };
+      check();
+    });
+  }
+
   get pendingSegments(): number {
     return this.queue.length;
   }


### PR DESCRIPTION
## Problem

Three coupled bugs caused branch playback to be visibly off-beat:

1. **Narration leads board by ~15-20s** — per-move hook fired BEFORE applying the move. User heard *"I play Nf6"* while the board still showed the previous position; the move only appeared when audio ended.
2. **Branch entry jumps without context** — board snapped to `startingFen` the instant `BranchStarted` fired, so the visual rewind happened BEFORE the opening narration that frames it.
3. **Snap-back precedes closing audio by ~30s** — `_waitForNarration` (= `audioQueue.waitUntilDone`) raced with React's `useEffect` that enqueues entries. When the closing narration completed, the await returned immediately (audio queue momentarily idle, entry not yet enqueued). The closing verdict then played on the already-snapped-back main-line position, with ~33s of dead air between the visual snap and the audio explaining it.

## Fix
- **Flip per-move loop in `executeBranch`**: apply move → emit `BranchMoveApplied` → THEN await narration hook. Board now leads audio (matches main-line pacing).
- **New event `BranchPositionRewound`**: emitted AFTER the opening narration; reducer snaps `currentFen` here, not on `BranchStarted`. `BranchStarted` carries new `mainLineFen` payload — board renders that during the opening cue.
- **New `AudioNarrationQueue.waitForEntryCount(target, timeoutMs=3000)`**: bridges the React-render gap. `tournamentStore`'s three branch hooks now capture `backlogEntries` before generating, wait for the count to bump (or timeout), then await drain.

## Test plan
- [ ] Typecheck — passes locally.
- [ ] Re-capture London + KID. Verify: per-move narration syncs to board; branch opening plays with board still on main line; snap-back happens AFTER the closing verdict audio finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timing synchronization between narration and board position during branch playback.

* **New Features**
  * Enhanced audio queue to better track narration completion during branch replay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mnehmos/LLM-Chess/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->